### PR TITLE
Convert relative image links to absolute image links per Terraform module official spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ of server nodes, which are responsible for being part of the [consensus
 quorum](https://www.consul.io/docs/internals/consensus.html), and a larger number of client nodes, which you typically 
 run alongside your apps:
 
-![Consul architecture](_docs/architecture.png)
+![Consul architecture](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/architecture.png?raw=true)
 
 
 
@@ -108,7 +108,7 @@ Gruntwork can help with:
 
 ## How do I contribute to this Module?
 
-Contributions are very welcome! Check out the [Contribution Guidelines](/CONTRIBUTING.md) for instructions.
+Contributions are very welcome! Check out the [Contribution Guidelines](https://github.com/hashicorp/terraform-aws-consul/tree/master/CONTRIBUTING.md) for instructions.
 
 
 
@@ -125,6 +125,6 @@ MINOR, and PATCH versions on each release to indicate any incompatibilities.
 
 ## License
 
-This code is released under the Apache 2.0 License. Please see [LICENSE](/LICENSE) and [NOTICE](/NOTICE) for more 
+This code is released under the Apache 2.0 License. Please see [LICENSE](https://github.com/hashicorp/terraform-aws-consul/tree/master/LICENSE) and [NOTICE](https://github.com/hashicorp/terraform-aws-consul/tree/master/NOTICE) for more 
 details.
 

--- a/_ci/publish-amis-in-new-account.md
+++ b/_ci/publish-amis-in-new-account.md
@@ -15,7 +15,7 @@ automated tests, which will fail when they cannot find the desired AMI.
 
 Our solution is that, for the `publish-amis` git branch only, on every commit, we will build and publish AMIs but we will
 not run tests. For all other branches, AMIs will only be built upon a new git tag (GitHub release), and tests will be
-run on every commit as usual. These settings are configured in the [circle.yml](/circle.yml) file.
+run on every commit as usual. These settings are configured in the [circle.yml](https://github.com/hashicorp/terraform-aws-consul/tree/master/circle.yml) file.
 
 In addition to the above, don't forget to update the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment 
 variables in CircleCI to reflect the new AWS account.

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -6,7 +6,7 @@ Groups (ASGs): one with a small number of Consul server nodes, which are respons
 quorum](https://www.consul.io/docs/internals/consensus.html), and one with a larger number of client nodes, which 
 would typically run alongside your apps:
 
-![Consul architecture](_docs/architecture.png)
+![Consul architecture](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/architecture.png?raw=true)
 
 You will need to create an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
 that has Consul installed, which you can do using the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami)). Note that to keep 

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -120,7 +120,7 @@ bar
 
 Finally, you can try opening up the Consul UI in your browser at the URL `http://11.22.33.44:8500/ui/`.
 
-![Consul UI](https://github.com/hashicorp/terraform-aws-consul/tree/master/_docs/consul-ui-screenshot.png)
+![Consul UI](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/consul-ui-screenshot.png?raw=true)
 
 
 ### Using the Consul agent on another EC2 Instance
@@ -164,7 +164,7 @@ Two important notes about this command:
 
 This module creates the following architecture:
 
-![Consul architecture](/_docs/architecture.png)
+![Consul architecture](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/architecture.png?raw=true)
 
 This architecture consists of the following resources:
 


### PR DESCRIPTION
Previously, image links were still expressed as relative links. Now all markdown links use the full repo URL.