### PR TITLE
Fix READMEs and bug in example startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ run alongside your apps:
 Each Module has the following folder structure:
 
 * [root](https://github.com/hashicorp/terraform-aws-consul/tree/master): This folder shows an example of Terraform code 
-that uses the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) 
-module to deploy 
-                                                                         a [Consul](https://www.consul.io/) cluster in [AWS](https://aws.amazon.com/).
+  that uses the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) 
+  module to deploy a [Consul](https://www.consul.io/) cluster in [AWS](https://aws.amazon.com/).
 * [modules](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules): This folder contains the reusable code for this Module, broken down into one or more modules.
 * [examples](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples): This folder contains examples of how to use the modules.
 * [test](https://github.com/hashicorp/terraform-aws-consul/tree/master/test): Automated tests for the modules and examples.

--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -68,7 +68,7 @@ Your code should look more like this:
   "provisioners": [{
     "type": "shell",
     "inline": [
-      "git clone --branch <BLUEPRINT_VERSION> https://github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul",
+      "git clone --branch <MODULE_VERSION> https://github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul",
       "/tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
       "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"
     ],
@@ -77,7 +77,7 @@ Your code should look more like this:
 }
 ```
 
-You should replace `<BLUEPRINT_VERSION>` in the code above with the version of this module that you want to use (see
+You should replace `<MODULE_VERSION>` in the code above with the version of this module that you want to use (see
 the [Releases Page](../../releases) for all available versions). That's because for production usage, you should always
 use a fixed, known version of this Module, downloaded from the official Git repo. On the other hand, when you're 
 just experimenting with the Module, it's OK to use a local checkout of the Module, uploaded from your own 

--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -113,7 +113,7 @@ function wait_for_all_consul_servers_to_register {
     log_info "Running 'consul members' command against server at IP address $server_ip"
     # Intentionally use local and readonly here so that this script doesn't exit if the consul members or grep commands
     # exit with an error.
-    local readonly members=$(consul members -rpc-addr="$server_ip:8400")
+    local readonly members=$(consul members -http-addr="$server_ip:8500")
     local readonly server_members=$(echo "$members" | grep "server")
     local readonly num_servers=$(echo "$server_members" | wc -l | tr -d ' ')
 
@@ -157,7 +157,7 @@ function print_instructions {
   local instructions=()
   instructions+=("\nYour Consul servers are running at the following IP addresses:\n\n${server_ips[@]/#/    }\n")
   instructions+=("Some commands for you to try:\n")
-  instructions+=("    consul members -rpc-addr=$server_ip:8400")
+  instructions+=("    consul members -http-addr=$server_ip:8500")
   instructions+=("    consul kv put -http-addr=$server_ip:8500 foo bar")
   instructions+=("    consul kv get -http-addr=$server_ip:8500 foo")
   instructions+=("\nTo see the Consul UI, open the following URL in your web browser:\n")

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -88,7 +88,7 @@ Your Consul servers are running at the following IP addresses:
 You can use one of these IP addresses with the `members` command to see a list of cluster nodes:
 
 ```
-> consul members -rpc-addr=11.22.33.44:8400
+> consul members -http-addr=11.22.33.44:8500
 
 Node                 Address             Status  Type    Build  Protocol  DC
 i-0051c3ea00e9691a0  172.31.35.148:8301  alive   client  0.8.0  2         us-east-1


### PR DESCRIPTION
1. The latest version of Consul uses `-http-addr` and not `rpc-addr`. Update the example script to use it.
1. Fix some minor issues in the READMEs.