### PR TITLE
ability to supply vpc_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -152,7 +152,7 @@ data "template_file" "user_data_client" {
 
 data "aws_vpc" "default" {
   default = "${var.vpc_id == "" ? true : false}"
-  id = "${var.vpc_id == "" ? "" : var.vpc_id}"
+  id = "${var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,8 @@ data "template_file" "user_data_client" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "aws_vpc" "default" {
-  default = true
+  default = "${var.vpc_id == "" ? true : false}"
+  id = "${var.vpc_id == "" ? "" : var.vpc_id}"
 }
 
 data "aws_subnet_ids" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,8 @@ variable "ssh_key_name" {
   description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
   default     = ""
 }
+
+variable "vpc_id" {
+    description = "The ID of the VPC in which the nodes will be deployed.  Uses default VPC if not supplied."
+    default = ""
+}


### PR DESCRIPTION
Adds the ability to optionally deploy the consul agents to a specified VPC.  The default behavior is still maintained, in that if `vpc_id` is not supplied, the default VPC is used.