### PR TITLE
Update consul-cluster documentation

### DIFF
--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -22,16 +22,50 @@ For more info on how the Consul cluster works, check out the [consul-cluster](ht
 
 To deploy a Consul Cluster:
 
-1. `git clone` this repo to your computer.
 1. Build a Consul AMI. See the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami) documentation for instructions. Make sure to
    note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
-1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
+1. Create your main.tf file and include the consul-cluster module as per example
+```hcl
+#demo consul cluster
+module "consul_cluster" {
+  # Use version v0.0.5 of the consul-cluster module (or check latest tags)
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.0.5"
+
+  # Specify the ID of the Consul AMI. You should build this using the scripts in the install-consul module.
+  ami_id = "ami-6820c012" # Ubuntu AMi, do not use in production. 
+  instance_type = "t2.medium"
+  cluster_name = "${var.cluster_name}"
+  cluster_size = "${var.num_servers}"
+  ssh_key_name = "${aws_key_pair.auth.key_name}"
+
+  # Add this tag to each node in the cluster
+  cluster_tag_key   = "demo-consul-cluster"
+  cluster_tag_value = "demo-consul-cluster-example"
+
+  # Configure and start Consul during boot. It will automatically form a cluster with all nodes that have that same tag.
+  user_data = <<-EOF
+              #!/bin/bash
+              /opt/consul/bin/run-consul --server --cluster-tag-key demo-consul-cluster
+              EOF
+
+  # ... See variables.tf for the other parameters you must define for the consul-cluster module
+  vpc_id = "${aws_vpc.vpc_consul_cluster.id}"
+  subnet_ids = [ "${aws_subnet.subnet_consul_cluster.id}" ]
+  allowed_inbound_cidr_blocks = [ "0.0.0.0/0" ] # only use for testing, unsafe
+  allowed_ssh_cidr_blocks = [ "0.0.0.0/0" ] # only use for testing, unsafe
+  associate_public_ip_address = true
+}
+```
+A full example is included [here](https://github.com/hashicorp/terraform-aws-consul/blob/master/examples/root-example/main.tf) with a minimal infrastructure included. 
+Please notice this expects you have an RSA key set up in your .ssh folder, `~/.ssh/id_rsa` and `~/.ssh/id_rsa.pub`.
+This example is just for a demo, for production please refactor it following best practices.
+1. If you need to customise it check [variables.tf](https://github.com/hashicorp/terraform-aws-consul/blob/master/modules/consul-cluster/variables.tf), as a reference for the 
+	environment variables and their meaning.
 1. Run `terraform get`.
 1. Run `terraform plan`.
 1. If the plan looks good, run `terraform apply`.
 1. Run the [consul-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-examples-helper/consul-examples-helper.sh) to 
    print out the IP addresses of the Consul servers and some example commands you can run to interact with the cluster:
-   `../consul-examples-helper/consul-examples-helper.sh`.
+   `../consul-examples-helper/consul-examples-helper.sh`. (notice you need consul and awscli installed)
 

--- a/examples/root-example/main.tf
+++ b/examples/root-example/main.tf
@@ -1,0 +1,121 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret}"
+  region     = "${var.region}"
+}
+
+
+resource "aws_key_pair" "consul_cluster_key_pair" {
+  key_name   = "${var.key_name}"
+  public_key = "${file(var.public_key_path)}"
+}
+
+#demo consul cluster
+module "consul_cluster" {
+  # Use version v0.0.5 of the consul-cluster module
+  source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.0.5"
+
+  # Specify the ID of the Consul AMI. You should build this using the scripts in the install-consul module.
+  ami_id = "ami-6820c012"
+  instance_type = "t2.medium"
+  # aws_region = "${var.region}"
+  cluster_name = "${var.cluster_name}"
+  # num_servers = "${var.num_servers}"
+  cluster_size = "${var.num_servers}"
+  ssh_key_name = "${aws_key_pair.consul_cluster_key_pair.key_name}"
+
+  # Add this tag to each node in the cluster
+  cluster_tag_key   = "demo-consul-cluster"
+  cluster_tag_value = "demo-consul-cluster-example"
+
+  # Configure and start Consul during boot. It will automatically form a cluster with all nodes that have that same tag.
+  user_data = <<-EOF
+              #!/bin/bash
+              /opt/consul/bin/run-consul --server --cluster-tag-key demo-consul-cluster
+              EOF
+
+  # ... See variables.tf for the other parameters you must define for the consul-cluster module
+  vpc_id = "${aws_vpc.vpc_consul_cluster.id}"
+  subnet_ids = [ "${aws_subnet.subnet_consul_cluster.id}" ]
+  allowed_inbound_cidr_blocks = [ "0.0.0.0/0" ]
+  allowed_ssh_cidr_blocks = [ "0.0.0.0/0" ]
+  associate_public_ip_address = true
+}
+
+#networking
+
+# Create a VPC to launch our instances into
+resource "aws_vpc" "vpc_consul_cluster" {
+  tags {
+    Name = "Consul Cluster VPC"
+  }
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+}
+
+# Create an internet gateway to give our subnet access to the outside world
+resource "aws_internet_gateway" "gateway_consul_cluster" {
+  tags {
+    Name = "Consul Cluster Internet Gateway"
+  }
+  vpc_id = "${aws_vpc.vpc_consul_cluster.id}"
+}
+
+# Grant the VPC internet access on its main route table
+resource "aws_route" "consul_cluster_internet_access" {
+  route_table_id         = "${aws_vpc.vpc_consul_cluster.main_route_table_id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.gateway_consul_cluster.id}"
+}
+
+# Create a subnet to launch our instances into
+resource "aws_subnet" "subnet_consul_cluster" {
+  vpc_id                  = "${aws_vpc.vpc_consul_cluster.id}"
+  cidr_block              = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+}
+
+# Our default security group to access
+# the instances over SSH and HTTP
+resource "aws_security_group" "sec_group_consul_cluster" {
+  name        = "demo Consul Cluster security"
+  description = "Used for demo Consul Cluster"
+  vpc_id      = "${aws_vpc.vpc_consul_cluster.id}"
+
+  # SSH access from anywhere
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Consul Cluster Service access from anywhere
+  ingress {
+    from_port   = 8301
+    to_port     = 8301
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Consul HTTP API access from anywhere
+  ingress {
+    from_port   = 8500
+    to_port     = 8500
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # outbound internet access
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_network_interface" "consul_cluster_network_interface" {
+  subnet_id   = "${aws_subnet.subnet_consul_cluster.id}"
+  private_ips = ["10.0.1.10"]
+}

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -3,7 +3,7 @@
 This folder contains a [Terraform](https://www.terraform.io/) module to deploy a 
 [Consul](https://www.consul.io/) cluster in [AWS](https://aws.amazon.com/) on top of an Auto Scaling Group. This module 
 is designed to deploy an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
-that has Consul installed via the [install-consul](../../modules/install-consul) module in this Module.
+that has Consul installed via the [install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) module in this Module.
 
 
 
@@ -15,32 +15,24 @@ code by adding a `module` configuration and setting its `source` parameter to UR
 ```hcl
 #demo consul cluster
 module "consul_cluster" {
-  # Use version v0.0.5 of the consul-cluster module (or check latest tags)
+  # TODO: update this to the final URL
+  # Use version v0.0.5 of the consul-cluster module
   source = "github.com/hashicorp/terraform-aws-consul//modules/consul-cluster?ref=v0.0.5"
 
   # Specify the ID of the Consul AMI. You should build this using the scripts in the install-consul module.
-  ami_id = "ami-6820c012" # Ubuntu AMi, do not use in producuction
-  instance_type = "t2.medium"
-  cluster_name = "${var.cluster_name}"
-  cluster_size = "${var.num_servers}"
-  ssh_key_name = "${aws_key_pair.auth.key_name}"
-
+  ami_id = "ami-abcd1234"
+  
   # Add this tag to each node in the cluster
-  cluster_tag_key   = "demo-consul-cluster"
-  cluster_tag_value = "demo-consul-cluster-example"
-
-  # Configure and start Consul during boot. It will automatically form a cluster with all nodes that have that same tag.
+  cluster_tag_key   = "consul-cluster"
+  cluster_tag_value = "consul-cluster-example"
+  
+  # Configure and start Consul during boot. It will automatically form a cluster with all nodes that have that same tag. 
   user_data = <<-EOF
               #!/bin/bash
-              /opt/consul/bin/run-consul --server --cluster-tag-key demo-consul-cluster
+              /opt/consul/bin/run-consul --server --cluster-tag-key consul-cluster
               EOF
-
+  
   # ... See vars.tf for the other parameters you must define for the consul-cluster module
-  vpc_id = "${aws_vpc.vpc_consul_cluster.id}"
-  subnet_ids = [ "${aws_subnet.subnet_consul_cluster.id}" ]
-  allowed_inbound_cidr_blocks = [ "0.0.0.0/0" ] # only use for testing, unsafe
-  allowed_ssh_cidr_blocks = [ "0.0.0.0/0" ] # only use for testing, unsafe
-  associate_public_ip_address = true
 }
 ```
 
@@ -127,7 +119,7 @@ bar
 
 Finally, you can try opening up the Consul UI in your browser at the URL `http://11.22.33.44:8500/ui/`.
 
-![Consul UI](../../_docs/consul-ui-screenshot.png?raw=true)
+![Consul UI](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/consul-ui-screenshot.png?raw=true)
 
 
 ### Using the Consul agent on another EC2 Instance
@@ -171,7 +163,7 @@ Two important notes about this command:
 
 This module creates the following architecture:
 
-![Consul architecture](../../_docs/architecture.png?raw=true)
+![Consul architecture](https://github.com/hashicorp/terraform-aws-consul/blob/master/_docs/architecture.png?raw=true)
 
 This architecture consists of the following resources:
 
@@ -186,7 +178,7 @@ This architecture consists of the following resources:
 This module runs Consul on top of an [Auto Scaling Group (ASG)](https://aws.amazon.com/autoscaling/). Typically, you
 should run the ASG with 3 or 5 EC2 Instances spread across multiple [Availability 
 Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). Each of the EC2
-Instances should be running an AMI that has Consul installed via the [install-consul](../install-consul)
+Instances should be running an AMI that has Consul installed via the [install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul)
 module. You pass in the ID of the AMI to run using the `ami_id` input parameter.
 
 
@@ -214,7 +206,7 @@ Check out the [Security section](#security) for more details.
 Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached. 
 We give this IAM role a small set of IAM permissions that each EC2 Instance can use to automatically discover the other 
 Instances in its ASG and form a cluster with them. See the [run-consul required permissions 
-docs](../run-consul#required-permissions) for details.
+docs](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul#required-permissions) for details.
 
 The IAM Role ARN is exported as an output variable if you need to add additional permissions. 
 
@@ -283,14 +275,14 @@ Here are some of the main security considerations to keep in mind when using thi
 ### Encryption in transit
 
 Consul can encrypt all of its network traffic. For instructions on enabling network encryption, have a look at the
-[How do you handle encryption documentation](../run-consul#how-do-you-handle-encryption).
+[How do you handle encryption documentation](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul#how-do-you-handle-encryption).
 
 
 ### Encryption at rest
 
 The EC2 Instances in the cluster store all their data on the root EBS Volume. To enable encryption for the data at
 rest, you must enable encryption in your Consul AMI. If you're creating the AMI using Packer (e.g. as shown in
-the [consul-ami example](../../examples/consul-ami)), you need to set the [encrypt_boot 
+the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami)), you need to set the [encrypt_boot 
 parameter](https://www.packer.io/docs/builders/amazon-ebs.html#encrypt_boot) to `true`.  
 
 


### PR DESCRIPTION
I have tried to work out a correct minimal consul cluster example based on the previous old documentation. I think this is an improvement but I am getting error 500 on the cluster instances

```
HTTP error code from Consul: 500 Internal Server Error

Error message from Consul: No cluster leader
```
I am unsure what is needed to get this fixed. I am opening the PR to both fix the documentation and be able to run a minimal example cluster. If you have any idea pls let me know. I will check logs in the instances in the meantime. Also pls give me some feedback on the documentation