### PR TITLE
Fix outdated links to vars.tf

### DIFF
--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -26,7 +26,7 @@ To deploy a Consul Cluster:
 1. Build a Consul AMI. See the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami) documentation for instructions. Make sure to
    note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
-1. Open `vars.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
+1. Open `variables.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
    don't have a default, including putting your AMI ID into the `ami_id` variable.
 1. Run `terraform get`.
 1. Run `terraform plan`.

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -31,7 +31,7 @@ module "consul_cluster" {
               /opt/consul/bin/run-consul --server --cluster-tag-key consul-cluster
               EOF
   
-  # ... See vars.tf for the other parameters you must define for the consul-cluster module
+  # ... See variables.tf for the other parameters you must define for the consul-cluster module
 }
 ```
 
@@ -53,7 +53,7 @@ Note the following parameters:
   run Consul. The `run-consul` script is one of the scripts installed by the [install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) 
   module. 
 
-You can find the other parameters in [vars.tf](vars.tf).
+You can find the other parameters in [variables.tf](variables.tf).
 
 Check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for fully-working sample code. 
 
@@ -304,7 +304,7 @@ This module attaches a security group to each EC2 Instance that allows inbound r
   [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access. You can use the `allowed_inbound_ssh_security_group_ids` parameter to control the list of source Security Groups that will be allowed access.
   
 Note that all the ports mentioned above are configurable via the `xxx_port` variables (e.g. `server_rpc_port`). See
-[vars.tf](vars.tf) for the full list.  
+[variables.tf](variables.tf) for the full list.  
   
   
 

--- a/modules/consul-iam-policies/README.md
+++ b/modules/consul-iam-policies/README.md
@@ -42,6 +42,6 @@ Note the following parameters:
 * `iam_role_id`: Use this parameter to specify the ID of the IAM Role to which the rules in this module
   should be added.
   
-You can find the other parameters in [vars.tf](vars.tf).
+You can find the other parameters in [variables.tf](variables.tf).
 
 Check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for working sample code.

--- a/modules/consul-security-group-rules/README.md
+++ b/modules/consul-security-group-rules/README.md
@@ -42,6 +42,6 @@ Note the following parameters:
 * `security_group_id`: Use this parameter to specify the ID of the security group to which the rules in this module
   should be added.
   
-You can find the other parameters in [vars.tf](vars.tf).
+You can find the other parameters in [variables.tf](variables.tf).
 
 Check out the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.


### PR DESCRIPTION
The official Terraform Module standard requires that files be named `variables.tf` instead of `vars.tf`. Looks like we forgot to update some of these links. Fixes #26 