### PR TITLE
Fixed symlink issues on CentOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ terraform.tfvars
 build/
 */build/
 out/
+# VIM Swap files
+*.swp
 
 # Go best practices dictate that libraries should not include the vendor directory
 vendor

--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -17,6 +17,10 @@ in Consul). To see how to deploy this AMI, check out the [consul-cluster example
 For more info on Consul installation and configuration, check out the 
 [install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) and [install-dnsmasq](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) documentation.
 
+## Dependencies
+1.  AWSCLI must be installed on the base AMI in order for run-consul to run
+1.  PIP must be installed on the base AMI in order to install supervisord
+1.  Git CAN be installed on the base AMI if you want to use clone commands
 
 
 ## Quick start

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -78,8 +78,8 @@ function install_supervisord_debian {
 }
 
 function two_way_symlink() {
-  src=$1
-  dest=$2
+  local src="$1"
+  local dest="$2"
 
   if [[ ! -f "$dest" ]] && [[ ! -f "$src" ]]; then
     echo "Missing source AND destination... exiting..."

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -99,14 +99,14 @@ function install_supervisord_amazon_linux {
 
   if [[ ! -f "/usr/local/bin/supervisord" ]]; then
     if [[ -f "/usr/bin/supervisord" ]]; then
-      sudo ln -s /usr/bin/supervisorctl /usr/local/bin/supervisorctl
+      sudo ln -s /usr/bin/supervisord /usr/local/bin/supervisord
     else
       echo "Unable to find supervisord... exiting"
       exit -5
     fi
   elif [[ ! -f "/usr/bin/supervisord" ]]; then
     if [[ -f "/usr/local/bin/supervisord" ]]; then
-      sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
+      sudo ln -s /usr/local/bin/supervisord /usr/bin/supervisord
     fi
   fi
 

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -82,11 +82,32 @@ function install_supervisord_amazon_linux {
   sudo pip install supervisor
 
   # On Amazon Linux, /usr/local/bin is not in PATH for the root user, so we add symlinks to /usr/bin, which is in PATH
-  if [[ ! -f "/usr/bin/supervisorctl" ]]; then
-    sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
+  if [[ ! -f "/usr/local/bin/supervisorctl" ]]; then
+    if [[ -f "/usr/bin/supervisorctl" ]]; then
+      sudo ln -s /usr/bin/supervisorctl /usr/local/bin/supervisorctl
+    else
+      echo "Unable to find supervisorctl tool... exiting"
+      exit -5
+    fi
+  elif [[ ! -f "/usr/bin/supervisorctl" ]]; then
+    # IF supervisorctl does NOT exist in /usr/bin, check for it in /usr/local/bin and link it to /usr/bin
+    if [[ -f "/usr/local/bin/supervisorctl" ]]; then
+      sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
+
+    fi
   fi
-  if [[ ! -f "/usr/bin/supervisord" ]]; then
-    sudo ln -s /usr/local/bin/supervisord /usr/bin/supervisord
+
+  if [[ ! -f "/usr/local/bin/supervisord" ]]; then
+    if [[ -f "/usr/bin/supervisord" ]]; then
+      sudo ln -s /usr/bin/supervisorctl /usr/local/bin/supervisorctl
+    else
+      echo "Unable to find supervisord... exiting"
+      exit -5
+    fi
+  elif [[ ! -f "/usr/bin/supervisord" ]]; then
+    if [[ -f "/usr/local/bin/supervisord" ]]; then
+      sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
+    fi
   fi
 
   sudo cp "$SCRIPT_DIR/supervisor-initd-script.sh" "/etc/init.d/supervisor"

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -77,38 +77,33 @@ function install_supervisord_debian {
   sudo systemctl enable supervisor
 }
 
+function two_way_symlink() {
+  src=$1
+  dest=$2
+
+  if [[ ! -f "$dest" ]] && [[ ! -f "$src" ]]; then
+    echo "Missing source AND destination... exiting..."
+    exit -5
+  fi
+
+  if [[ ! -f "$dest" ]]; then
+    ## Destination isn't there point it to source
+    sudo ln -s $src  $dest
+  elif [[ ! -f "$src" ]]; then
+    ## Source file was missing, point to destination.  Should ONLY do so if it doesn't already exist (e.g. hadn't already been dual linked)
+    sudo ln -s $dest $src
+  fi
+
+
+}
+
 # Install steps are based on: http://stackoverflow.com/a/31576473/483528
 function install_supervisord_amazon_linux {
   sudo pip install supervisor
 
   # On Amazon Linux, /usr/local/bin is not in PATH for the root user, so we add symlinks to /usr/bin, which is in PATH
-  if [[ ! -f "/usr/local/bin/supervisorctl" ]]; then
-    if [[ -f "/usr/bin/supervisorctl" ]]; then
-      sudo ln -s /usr/bin/supervisorctl /usr/local/bin/supervisorctl
-    else
-      echo "Unable to find supervisorctl tool... exiting"
-      exit -5
-    fi
-  elif [[ ! -f "/usr/bin/supervisorctl" ]]; then
-    # IF supervisorctl does NOT exist in /usr/bin, check for it in /usr/local/bin and link it to /usr/bin
-    if [[ -f "/usr/local/bin/supervisorctl" ]]; then
-      sudo ln -s /usr/local/bin/supervisorctl /usr/bin/supervisorctl
-
-    fi
-  fi
-
-  if [[ ! -f "/usr/local/bin/supervisord" ]]; then
-    if [[ -f "/usr/bin/supervisord" ]]; then
-      sudo ln -s /usr/bin/supervisord /usr/local/bin/supervisord
-    else
-      echo "Unable to find supervisord... exiting"
-      exit -5
-    fi
-  elif [[ ! -f "/usr/bin/supervisord" ]]; then
-    if [[ -f "/usr/local/bin/supervisord" ]]; then
-      sudo ln -s /usr/local/bin/supervisord /usr/bin/supervisord
-    fi
-  fi
+  two_way_symlink "/usr/bin/supervisorctl" "/usr/local/bin/supervisorctl"
+  two_way_symlink "/usr/bin/supervisord" "/usr/local/bin/supervisord"
 
   sudo cp "$SCRIPT_DIR/supervisor-initd-script.sh" "/etc/init.d/supervisor"
   sudo chmod a+x /etc/init.d/supervisor

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -82,7 +82,7 @@ function two_way_symlink() {
   local dest="$2"
 
   if [[ ! -f "$dest" ]] && [[ ! -f "$src" ]]; then
-    echo "Missing source AND destination... exiting..."
+    echo "Missing source '$src' AND destination '$dest' exiting..."
     exit -5
   fi
 


### PR DESCRIPTION
Should fix the symlink issues for people.  Does it both directions and then fails the script if it can't find supervisorctl/supervisord