### PR TITLE
Add tags variable to allow passing in extra tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,14 @@ module "consul_servers" {
 
   allowed_inbound_cidr_blocks = ["0.0.0.0/0"]
   ssh_key_name                = "${var.ssh_key_name}"
+
+  tags = [
+    {
+      key                 = "Environment"
+      value               = "development"
+      propagate_at_launch = true
+    },
+  ]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -28,17 +28,19 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_grace_period = "${var.health_check_grace_period}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
 
-  tag {
-    key                 = "Name"
-    value               = "${var.cluster_name}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "${var.cluster_tag_key}"
-    value               = "${var.cluster_tag_value}"
-    propagate_at_launch = true
-  }
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.cluster_name}"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "${var.cluster_tag_key}"
+      value               = "${var.cluster_tag_value}"
+      propagate_at_launch = true
+    },
+    "${var.tags}",
+  ]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -184,3 +184,9 @@ variable "ssh_port" {
   description = "The port used for SSH connections"
   default     = 22
 }
+
+variable "tags" {
+  description = "List fo extra tag blocks added to the autoscaling group configuration"
+  type        = "list"
+  default     = []
+}

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -186,7 +186,7 @@ variable "ssh_port" {
 }
 
 variable "tags" {
-  description = "List fo extra tag blocks added to the autoscaling group configuration"
+  description = "List fo extra tag blocks added to the autoscaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
   type        = "list"
   default     = []
 }


### PR DESCRIPTION
This PR adds a new variable `tags` to pass in extra tag blocks for the autoscaling group, and via tag propagation (if enabled) also to the instances.

My use case is building a complete environment of which a consul cluster is part. All resources in that environment need to be tagged with custom tags. Examples of such tags are the name of the environment and a flag to determine if monitoring should be enabled on those resources.

I've tested this PR using test-kitchen and awspec.

I've specified tags like this:
```hcl
module "consul_cluster" {
  source = "github.com/miguelaferreira/terraform-aws-consul//modules/consul-cluster?ref=extra-tags"

  ...

  tags = [
    {
      key                 = "Project"
      value               = "${var.project}"
      propagate_at_launch = true
    },
    {
      key                 = "Environment"
      value               = "${var.environment}"
      propagate_at_launch = true
    },
    {
      key                 = "Monitoring"
      value               = "${var.monitoring_enabled ? "true" : "false"}"
      propagate_at_launch = true
    },
  ]
}
```

And I have an awspec test that looks like this:
```ruby
require 'awspec'
require 'rubygems'

tf_output = eval(ENV['KITCHEN_KITCHEN_TERRAFORM_OUTPUT'])

consul_autoscaling_group_name = tf_output[:consul_autoscaling_group_name][:value]

describe autoscaling_group(consul_autoscaling_group_name) do
  it { should exist }
  it { should have_tag('Project').value('project') }
  it { should have_tag('Environment').value('test') }
  it { should have_tag('Monitoring').value('true') }
end
```

The test results were:
```
autoscaling_group 'NloGatewayTestConsul20180221102548649600000011'
  should exist
  should have tag "Project"
  should have tag "Environment"
  should have tag "Monitoring"

Finished in 0.29098 seconds (files took 1.89 seconds to load)
4 examples, 0 failures
```