### PR TITLE
Use variable cluster_name as a name prefix for the autoscaling group

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -11,6 +11,8 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_autoscaling_group" "autoscaling_group" {
+  name_prefix = "${var.cluster_name}"
+
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
 
   availability_zones  = ["${var.availability_zones}"]


### PR DESCRIPTION
This PR reuses the `cluter_name` variable to set `name_prefix` on the cluster autoscaling group resource. 

As the documentation mentions, the `cluster_name` should be "*used to namespace all resources created by this module*".

I've tested this PR with test-ktichen and awspec. I've defined the name of the cluster like this:
```hcl
module "consul_cluster" {
  source = "github.com/miguelaferreira/terraform-aws-consul//modules/consul-cluster?ref=namespace-autoscaling-group"

  cluster_name = "ProjectTestConsul"

  ...
}
```

I wrote a awspec test like this:
```ruby
require 'awspec'
require 'rubygems'

tf_output = eval(ENV['KITCHEN_KITCHEN_TERRAFORM_OUTPUT'])

consul_autoscaling_group_name = tf_output[:consul_autoscaling_group_name][:value]

describe consul_autoscaling_group_name do
  it { should start_with 'ProjectTestConsul' }
end
```

The results were:
```
ProjectTestConsul20180221110521541200000011
  should start with "ProjectTestConsul"

...

Finished in 0.17729 seconds (files took 1.85 seconds to load)
5 examples, 0 failures
```