### PR TITLE
Add Name tag to Consul Security Group

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -97,6 +97,10 @@ resource "aws_security_group" "lc_security_group" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags {
+    Name = "${var.cluster_name}"
+  }
 }
 
 resource "aws_security_group_rule" "allow_ssh_inbound" {


### PR DESCRIPTION
When using this module to create a stand alone Consul cluster, it is
helpful to be able to use a data source to import the SG in order to
configure other modules. e.g. a separate Nomad cluster module with its 
own TF state to add an SG rule to allow the Nomad clients, also Consul 
clients, to talk to the main Consul server SG.

Because we only give a name_prefix to this SG group currently, there is 
no way to use a data source to import based on name. Passing around
terraform outputs for this type of thing is a faff due to setup and
separate state.