### PR TITLE
Add simple sg rules for consul agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Gruntwork can help with:
 * [consul-security-group-rules](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-security-group-rules): Defines the security group rules used by a 
   Consul cluster to control the traffic that is allowed to go in and out of the cluster.
 
+* [consul-client-security-group-rules](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-client-security-group-rules): Defines the security group rules
+  used by a Consul agent to control the traffic that is allowed to go in and out.
 
 
 

--- a/modules/consul-client-security-group-rules/README.md
+++ b/modules/consul-client-security-group-rules/README.md
@@ -1,0 +1,47 @@
+# Consul Client Security Group Rules Module
+
+This folder contains a [Terraform](https://www.terraform.io/) module that defines the security group rules used by a 
+[Consul](https://www.consul.io/) client to control the traffic that is allowed to go in and out. 
+
+Normally, you'd get these rules by default if you're using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md), but if 
+you're running Consul on top of a different cluster, then you can use this module to add the necessary security group 
+rules to that cluster. For example, imagine you were using the [vault-cluster 
+module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) to run a cluster of 
+servers that have both Vault and Consul agent on each node:
+
+```hcl
+module "vault_servers" {
+  source = "git::git@github.com:hashicorp/terraform-aws-vault.git//modules/vault-cluster?ref=v0.0.1"
+  
+  # This AMI has both Vault and Consul installed
+  ami_id = "ami-1234abcd"
+}
+```
+
+The `vault-cluster` module will provide the security group rules for Vault, but not for the Consul agent. To ensure those servers
+have the necessary ports open for using Consul, you can use this module as follows:
+
+```hcl
+module "security_group_rules" {
+  source = "git::git@github.com:hashicorp/terraform-aws-consul.git//modules/consul-client-security-group-rules?ref=v0.0.2"
+
+  security_group_id = "${module.vault_servers.security_group_id}"
+  
+  # ... (other params omitted) ...
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of this module. The double slash (`//`) is intentional 
+  and required. Terraform uses it to specify subfolders within a Git repo (see [module 
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+  will change every time you run Terraform, you're using a fixed version of the repo.
+
+* `security_group_id`: Use this parameter to specify the ID of the security group to which the rules in this module
+  should be added.
+  
+You can find the other parameters in [variables.tf](variables.tf).
+
+Check out the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.

--- a/modules/consul-client-security-group-rules/main.tf
+++ b/modules/consul-client-security-group-rules/main.tf
@@ -1,0 +1,47 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE THE SECURITY GROUP RULES THAT CONTROL WHAT TRAFFIC CAN GO IN AND OUT OF A CONSUL AGENT CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group_rule" "allow_serf_lan_tcp_inbound" {
+  count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
+  type        = "ingress"
+  from_port   = "${var.serf_lan_port}"
+  to_port     = "${var.serf_lan_port}"
+  protocol    = "tcp"
+  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+
+  security_group_id = "${var.security_group_id}"
+}
+
+resource "aws_security_group_rule" "allow_serf_lan_udp_inbound" {
+  count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
+  type        = "ingress"
+  from_port   = "${var.serf_lan_port}"
+  to_port     = "${var.serf_lan_port}"
+  protocol    = "udp"
+  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
+
+  security_group_id = "${var.security_group_id}"
+}
+
+resource "aws_security_group_rule" "allow_serf_lan_tcp_inbound_from_security_group_ids" {
+  count                    = "${length(var.allowed_inbound_security_group_ids)}"
+  type                     = "ingress"
+  from_port                = "${var.serf_lan_port}"
+  to_port                  = "${var.serf_lan_port}"
+  protocol                 = "tcp"
+  source_security_group_id = "${element(var.allowed_inbound_security_group_ids, count.index)}"
+
+  security_group_id = "${var.security_group_id}"
+}
+
+resource "aws_security_group_rule" "allow_serf_lan_udp_inbound_from_security_group_ids" {
+  count                    = "${length(var.allowed_inbound_security_group_ids)}"
+  type                     = "ingress"
+  from_port                = "${var.serf_lan_port}"
+  to_port                  = "${var.serf_lan_port}"
+  protocol                 = "udp"
+  source_security_group_id = "${element(var.allowed_inbound_security_group_ids, count.index)}"
+
+  security_group_id = "${var.security_group_id}"
+}

--- a/modules/consul-client-security-group-rules/variables.tf
+++ b/modules/consul-client-security-group-rules/variables.tf
@@ -1,0 +1,29 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "security_group_id" {
+  description = "The ID of the security group to which we should add the Consul security group rules"
+}
+
+variable "allowed_inbound_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Consul"
+  type        = "list"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "allowed_inbound_security_group_ids" {
+  description = "A list of security group IDs that will be allowed to connect to Consul"
+  type        = "list"
+  default     = []
+}
+
+variable "serf_lan_port" {
+  description = "The port used to handle gossip in the LAN. Required by all agents."
+  default     = 8301
+}

--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -24,28 +24,6 @@ resource "aws_security_group_rule" "allow_cli_rpc_inbound" {
   security_group_id = "${var.security_group_id}"
 }
 
-resource "aws_security_group_rule" "allow_serf_lan_tcp_inbound" {
-  count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
-  type        = "ingress"
-  from_port   = "${var.serf_lan_port}"
-  to_port     = "${var.serf_lan_port}"
-  protocol    = "tcp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
-
-  security_group_id = "${var.security_group_id}"
-}
-
-resource "aws_security_group_rule" "allow_serf_lan_udp_inbound" {
-  count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
-  type        = "ingress"
-  from_port   = "${var.serf_lan_port}"
-  to_port     = "${var.serf_lan_port}"
-  protocol    = "udp"
-  cidr_blocks = ["${var.allowed_inbound_cidr_blocks}"]
-
-  security_group_id = "${var.security_group_id}"
-}
-
 resource "aws_security_group_rule" "allow_serf_wan_tcp_inbound" {
   count       = "${length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0}"
   type        = "ingress"
@@ -123,28 +101,6 @@ resource "aws_security_group_rule" "allow_cli_rpc_inbound_from_security_group_id
   security_group_id = "${var.security_group_id}"
 }
 
-resource "aws_security_group_rule" "allow_serf_lan_tcp_inbound_from_security_group_ids" {
-  count                    = "${length(var.allowed_inbound_security_group_ids)}"
-  type                     = "ingress"
-  from_port                = "${var.serf_lan_port}"
-  to_port                  = "${var.serf_lan_port}"
-  protocol                 = "tcp"
-  source_security_group_id = "${element(var.allowed_inbound_security_group_ids, count.index)}"
-
-  security_group_id = "${var.security_group_id}"
-}
-
-resource "aws_security_group_rule" "allow_serf_lan_udp_inbound_from_security_group_ids" {
-  count                    = "${length(var.allowed_inbound_security_group_ids)}"
-  type                     = "ingress"
-  from_port                = "${var.serf_lan_port}"
-  to_port                  = "${var.serf_lan_port}"
-  protocol                 = "udp"
-  source_security_group_id = "${element(var.allowed_inbound_security_group_ids, count.index)}"
-
-  security_group_id = "${var.security_group_id}"
-}
-
 resource "aws_security_group_rule" "allow_serf_wan_tcp_inbound_from_security_group_ids" {
   count                    = "${length(var.allowed_inbound_security_group_ids)}"
   type                     = "ingress"
@@ -198,4 +154,18 @@ resource "aws_security_group_rule" "allow_dns_udp_inbound_from_security_group_id
   source_security_group_id = "${element(var.allowed_inbound_security_group_ids, count.index)}"
 
   security_group_id = "${var.security_group_id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# THE CONSUL-CLIENT SPECIFIC INBOUND/OUTBOUND RULES COME FROM THE CONSUL-CLIENT-SECURITY-GROUP-RULES MODULE
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "client_security_group_rules" {
+  source = "../consul-client-security-group-rules"
+
+  security_group_id                  = "${var.security_group_id}"
+  allowed_inbound_cidr_blocks        = ["${var.allowed_inbound_cidr_blocks}"]
+  allowed_inbound_security_group_ids = ["${var.allowed_inbound_security_group_ids}"]
+
+  serf_lan_port   = "${var.serf_lan_port}"
 }


### PR DESCRIPTION
When deploying consul as an agent on, say a Vault cluster, I needed a set of rules to permit the LAN gossip traffic. This simple module permits that inbound traffic. Relates to https://github.com/hashicorp/terraform-aws-vault/pull/56