### PR TITLE
Install Git on Amazon Linux

### DIFF
--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -72,6 +72,7 @@ Your code should look more like this:
   "provisioners": [{
     "type": "shell",
     "inline": [
+      "sudo yum install -y git || true",
       "git clone --branch <MODULE_VERSION> https://github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul",
       "/tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
       "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"

--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -72,7 +72,6 @@ Your code should look more like this:
   "provisioners": [{
     "type": "shell",
     "inline": [
-      "sudo yum install -y git || true",
       "git clone --branch <MODULE_VERSION> https://github.com/hashicorp/terraform-aws-consul.git /tmp/terraform-aws-consul",
       "/tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
       "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"
@@ -81,6 +80,8 @@ Your code should look more like this:
   }]
 }
 ```
+
+**NOTE:** Amazon Linux users will need to install Git first.
 
 You should replace `<MODULE_VERSION>` in the code above with the version of this module that you want to use (see
 the [Releases Page](../../releases) for all available versions). That's because for production usage, you should always


### PR DESCRIPTION
Amazon Linux does not have Git installed by default. The first provisioner step makes sure we install it. `|| true` is used for compatibility with Ubuntu-based builder which does not have `yum` package manager.

Otherwise Amazon Linux will fail with:

    ==> amazon-linux-ami: Provisioning with shell script: /var/folders/zr/k8_fxx5d1xx56n1m758byg4r0000gn/T/packer-shell218591116
    amazon-linux-ami: /tmp/script_3975.sh: line 2: git: command not found
    ==> amazon-linux-ami: Terminating the source AWS instance...