### PR TITLE
Remove provider and aws_region from examples

### DIFF
--- a/examples/example-with-encryption/main.tf
+++ b/examples/example-with-encryption/main.tf
@@ -6,10 +6,6 @@
 # the examples/example-with-encryption/packer/consul-with-certs.json Packer template.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 # Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
 # conditionals in this template to fail.
 terraform {
@@ -146,3 +142,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/examples/example-with-encryption/outputs.tf
+++ b/examples/example-with-encryption/outputs.tf
@@ -47,7 +47,7 @@ output "security_group_id_clients" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "consul_servers_cluster_tag_key" {

--- a/examples/example-with-encryption/variables.tf
+++ b/examples/example-with-encryption/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
@@ -14,11 +15,6 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/example-with-encryption/packer/consul-with-certs.json. To keep this example simple, we run the same AMI on both server and client nodes, but in real-world usage, your client nodes would also run your apps. If the default value is used, Terraform will look up the latest AMI build automatically."
   default     = ""
-}
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
 }
 
 variable "cluster_name" {

--- a/examples/root-example/README.md
+++ b/examples/root-example/README.md
@@ -23,14 +23,15 @@ For more info on how the Consul cluster works, check out the [consul-cluster](ht
 To deploy a Consul Cluster:
 
 1. `git clone` this repo to your computer.
-1. Build a Consul AMI. See the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami) documentation for instructions. Make sure to
+1. Optional: build a Consul AMI. See the [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami) documentation for instructions. Make sure to
    note down the ID of the AMI.
 1. Install [Terraform](https://www.terraform.io/).
 1. Open `variables.tf`, set the environment variables specified at the top of the file, and fill in any other variables that
-   don't have a default, including putting your AMI ID into the `ami_id` variable.
-1. Run `terraform get`.
-1. Run `terraform plan`.
-1. If the plan looks good, run `terraform apply`.
+   don't have a default. If you built a custom AMI, put the AMI ID into the `ami_id` variable. Otherwise, one of our
+   public example AMIs will be used by default. These AMIs are great for learning/experimenting, but are NOT
+   recommended for production use.
+1. Run `terraform init`.
+1. Run `terraform apply`.
 1. Run the [consul-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-examples-helper/consul-examples-helper.sh) to 
    print out the IP addresses of the Consul servers and some example commands you can run to interact with the cluster:
    `../consul-examples-helper/consul-examples-helper.sh`.

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,6 @@
 # the examples/consul-ami/consul.json Packer template.
 # ---------------------------------------------------------------------------------------------------------------------
 
-provider "aws" {
-  region = "${var.aws_region}"
-}
-
 # Terraform 0.9.5 suffered from https://github.com/hashicorp/terraform/issues/14399, which causes this template the
 # conditionals in this template to fail.
 terraform {
@@ -170,3 +166,5 @@ data "aws_vpc" "default" {
 data "aws_subnet_ids" "default" {
   vpc_id = "${data.aws_vpc.default.id}"
 }
+
+data "aws_region" "current" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,7 +47,7 @@ output "security_group_id_clients" {
 }
 
 output "aws_region" {
-  value = "${var.aws_region}"
+  value = "${data.aws_region.current.name}"
 }
 
 output "consul_servers_cluster_tag_key" {

--- a/test/Gopkg.lock
+++ b/test/Gopkg.lock
@@ -28,8 +28,8 @@
 [[projects]]
   name = "github.com/gruntwork-io/terratest"
   packages = ["modules/aws","modules/collections","modules/files","modules/logger","modules/packer","modules/random","modules/retry","modules/shell","modules/ssh","modules/terraform","modules/test-structure"]
-  revision = "9c235cf826d8e1bf92af71c93e421347447238e6"
-  version = "v0.9.0"
+  revision = "baaee143a328ab0fe3a78a0ebc80bb0f707ef8fc"
+  version = "v0.9.2"
 
 [[projects]]
   name = "github.com/hashicorp/consul"

--- a/test/Gopkg.toml
+++ b/test/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   name = "github.com/gruntwork-io/terratest"
-  version = "0.9.0"
+  version = "0.9.2"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/test/consul_helpers.go
+++ b/test/consul_helpers.go
@@ -16,7 +16,6 @@ import (
 
 const REPO_ROOT = "../"
 const CONSUL_CLUSTER_EXAMPLE_VAR_AMI_ID = "ami_id"
-const CONSUL_CLUSTER_EXAMPLE_VAR_AWS_REGION = "aws_region"
 const CONSUL_CLUSTER_EXAMPLE_VAR_CLUSTER_NAME = "cluster_name"
 const CONSUL_CLUSTER_EXAMPLE_VAR_NUM_SERVERS = "num_servers"
 const CONSUL_CLUSTER_EXAMPLE_VAR_NUM_CLIENTS = "num_clients"
@@ -28,6 +27,8 @@ const CONSUL_CLUSTER_EXAMPLE_OUTPUT_SERVER_ASG_NAME = "asg_name_servers"
 const CONSUL_CLUSTER_EXAMPLE_OUTPUT_CLIENT_ASG_NAME = "asg_name_clients"
 
 const SAVED_AWS_REGION = "AwsRegion"
+
+const AWS_DEFAULT_REGION_ENV_VAR = "AWS_DEFAULT_REGION"
 
 // Test the consul-cluster example by:
 //
@@ -64,11 +65,13 @@ func runConsulClusterTest(t *testing.T, packerBuildName string, examplesFolder s
 		terraformOptions := &terraform.Options{
 			TerraformDir: exampleFolder,
 			Vars: map[string]interface{}{
-				CONSUL_CLUSTER_EXAMPLE_VAR_AWS_REGION:   awsRegion,
 				CONSUL_CLUSTER_EXAMPLE_VAR_CLUSTER_NAME: uniqueId,
 				CONSUL_CLUSTER_EXAMPLE_VAR_NUM_SERVERS:  CONSUL_CLUSTER_EXAMPLE_DEFAULT_NUM_SERVERS,
 				CONSUL_CLUSTER_EXAMPLE_VAR_NUM_CLIENTS:  CONSUL_CLUSTER_EXAMPLE_DEFAULT_NUM_CLIENTS,
 				CONSUL_CLUSTER_EXAMPLE_VAR_AMI_ID:       amiId,
+			},
+			EnvVars: map[string]string{
+				AWS_DEFAULT_REGION_ENV_VAR: awsRegion,
 			},
 		}
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,7 @@
 
 # AWS_ACCESS_KEY_ID
 # AWS_SECRET_ACCESS_KEY
+# AWS_DEFAULT_REGION
 
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
@@ -14,11 +15,6 @@
 variable "ami_id" {
   description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/consul-ami/consul.json. To keep this example simple, we run the same AMI on both server and client nodes, but in real-world usage, your client nodes would also run your apps. If the default value is used, Terraform will look up the latest AMI build automatically."
   default     = ""
-}
-
-variable "aws_region" {
-  description = "The AWS region to deploy into (e.g. us-east-1)."
-  default     = "us-east-1"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
Fixes #49. 

I’m removing the `provider` block and `aws_region` variable from the examples in this repo so that they work properly with the instructions you get from the auto-generated docs on the [Terraform Registry page](https://registry.terraform.io/modules/hashicorp/consul/aws/0.3.3) for this module:

```hcl
module "consul" {
  source  = "hashicorp/consul/aws"
  version = "0.3.3"
}
```