### PR TITLE
Add environment variables to supervisord config

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -182,6 +182,13 @@ function assert_is_installed {
   fi
 }
 
+# Based on https://stackoverflow.com/a/17841619
+function join_by {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
 function generate_consul_config {
   local readonly server="${1}"
   local readonly config_dir="${2}"
@@ -290,7 +297,7 @@ autostart=true
 autorestart=true
 stopsignal=INT
 user=$consul_user
-environment=${environment[@]}
+environment=$(join_by "," "${environment[@]}")
 EOF
 }
 

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -43,7 +43,7 @@ function print_usage {
   echo -e "  --ca-path\t\tPath to the directory of CA files used to verify outgoing connections. Optional. Must be specified with --enable-rpc-encryption."
   echo -e "  --cert-file-path\t\tPath to the certificate file used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --key-file-path."
   echo -e "  --key-file-path\t\tPath to the certificate key used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --cert-file-path."
-  echo -e "  --environment\t\tA list of key/value pairs in the form 'KEY=\"val\",KEY2=\"val2\"' to pass to Consul as environment variables when starting it up. Optional."
+  echo -e "  --environment\t\A single environment variable in the key/value pair form 'KEY=\"val\"' to pass to Consul as environment variable when starting it up. Repeat this option for additional variables. Optional."
   echo -e "  --skip-consul-config\tIf this flag is set, don't generate a Consul configuration file. Optional. Default is false."
   echo
   echo "Example:"
@@ -276,7 +276,8 @@ function generate_supervisor_config {
   local readonly consul_log_dir="$4"
   local readonly consul_bin_dir="$5"
   local readonly consul_user="$6"
-  local readonly environment="$7"
+  shift 6
+  local readonly environment=("$@")
 
   log_info "Creating Supervisor config file to run Consul in $supervisor_config_path"
   cat > "$supervisor_config_path" <<EOF
@@ -289,7 +290,7 @@ autostart=true
 autorestart=true
 stopsignal=INT
 user=$consul_user
-environment=$environment
+environment=${environment[@]}
 EOF
 }
 
@@ -323,7 +324,7 @@ function run {
   local ca_path=""
   local cert_file_path=""
   local key_file_path=""
-  local environment=""
+  local environment=()
   local skip_consul_config="false"
   local all_args=()
 
@@ -405,7 +406,7 @@ function run {
         ;;
       --environment)
         assert_not_empty "$key" "$2"
-        environment="$2"
+        environment+=("$2")
         shift
         ;;
       --skip-consul-config)
@@ -473,7 +474,7 @@ function run {
     generate_consul_config "$server" "$config_dir" "$user" "$cluster_tag_key" "$cluster_tag_value" "$datacenter" "$enable_gossip_encryption" "$gossip_encryption_key" "$enable_rpc_encryption" "$ca_path" "$cert_file_path" "$key_file_path"
   fi
 
-  generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$data_dir" "$log_dir" "$bin_dir" "$user" "$environment"
+  generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$data_dir" "$log_dir" "$bin_dir" "$user" "${environment[@]}"
   start_consul
 }
 

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -43,6 +43,7 @@ function print_usage {
   echo -e "  --ca-path\t\tPath to the directory of CA files used to verify outgoing connections. Optional. Must be specified with --enable-rpc-encryption."
   echo -e "  --cert-file-path\t\tPath to the certificate file used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --key-file-path."
   echo -e "  --key-file-path\t\tPath to the certificate key used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --cert-file-path."
+  echo -e "  --environment\t\tA list of key/value pairs in the form 'KEY=\"val\",KEY2=\"val2\"' to pass to Consul as environment variables when starting it up. Optional."
   echo -e "  --skip-consul-config\tIf this flag is set, don't generate a Consul configuration file. Optional. Default is false."
   echo
   echo "Example:"
@@ -275,6 +276,7 @@ function generate_supervisor_config {
   local readonly consul_log_dir="$4"
   local readonly consul_bin_dir="$5"
   local readonly consul_user="$6"
+  local readonly environment="$7"
 
   log_info "Creating Supervisor config file to run Consul in $supervisor_config_path"
   cat > "$supervisor_config_path" <<EOF
@@ -287,6 +289,7 @@ autostart=true
 autorestart=true
 stopsignal=INT
 user=$consul_user
+environment=$environment
 EOF
 }
 
@@ -320,6 +323,7 @@ function run {
   local ca_path=""
   local cert_file_path=""
   local key_file_path=""
+  local environment=""
   local skip_consul_config="false"
   local all_args=()
 
@@ -399,6 +403,11 @@ function run {
         key_file_path="$2"
         shift
         ;;
+      --environment)
+        assert_not_empty "$key" "$2"
+        environment="$2"
+        shift
+        ;;
       --skip-consul-config)
         skip_consul_config="true"
         ;;
@@ -464,7 +473,7 @@ function run {
     generate_consul_config "$server" "$config_dir" "$user" "$cluster_tag_key" "$cluster_tag_value" "$datacenter" "$enable_gossip_encryption" "$gossip_encryption_key" "$enable_rpc_encryption" "$ca_path" "$cert_file_path" "$key_file_path"
   fi
 
-  generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$data_dir" "$log_dir" "$bin_dir" "$user"
+  generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$data_dir" "$log_dir" "$bin_dir" "$user" "$environment"
   start_consul
 }
 

--- a/test/consul_helpers.go
+++ b/test/consul_helpers.go
@@ -138,12 +138,13 @@ func testConsulCluster(t *testing.T, nodeIpAddress string) {
 func createConsulClient(t *testing.T, ipAddress string) *api.Client {
 	config := api.DefaultConfig()
 	config.Address = fmt.Sprintf("%s:8500", ipAddress)
-	client, err := api.NewClient(config)
-	config.HttpClient.Timeout = 5 * time.Second
 
+	client, err := api.NewClient(config)
 	if err != nil {
 		t.Fatalf("Failed to create Consul client due to error: %v", err)
 	}
+
+	config.HttpClient.Timeout = 5 * time.Second
 
 	return client
 }

--- a/test/consul_helpers.go
+++ b/test/consul_helpers.go
@@ -138,9 +138,9 @@ func testConsulCluster(t *testing.T, nodeIpAddress string) {
 func createConsulClient(t *testing.T, ipAddress string) *api.Client {
 	config := api.DefaultConfig()
 	config.Address = fmt.Sprintf("%s:8500", ipAddress)
+	client, err := api.NewClient(config)
 	config.HttpClient.Timeout = 5 * time.Second
 
-	client, err := api.NewClient(config)
 	if err != nil {
 		t.Fatalf("Failed to create Consul client due to error: %v", err)
 	}


### PR DESCRIPTION
To allow arbitrary environment variables to be used with Consul agent.

In particular, this is to enable the use of the new [beta UI](https://github.com/hashicorp/consul/pull/4086) by setting the environment variable `CONSUL_UI_BETA`. 

I have tested it with my setup and the environment variable is successfully passed to the Consul agent started by supervisord.