### PR TITLE
Allow enterprise install

### DIFF
--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -29,14 +29,15 @@ To build the Consul AMI:
 
 1. `git clone` this repo to your computer.
 1. Install [Packer](https://www.packer.io/).
-1. Configure your AWS credentials using one of the [options supported by the AWS 
+1. Configure your AWS credentials using one of the [options supported by the AWS
    SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
    set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. Update the `variables` section of the `consul.json` Packer template to configure the AWS region, Consul version, and 
-   Dnsmasq version you wish to use.
+1. Update the `variables` section of the `consul.json` Packer template to configure the AWS region, Consul version, and
+   Dnsmasq version you wish to use. If you want to install Consul Enterprise, skip the version variable and instead set 
+   the `download_url` to the full url that points to the consul enterprise zipped package.
 1. Run `packer build consul.json`.
 
-When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the 
+When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the
 [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md).
 
 

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -2,7 +2,7 @@
   "min_packer_version": "0.12.0",
   "variables": {
     "aws_region": "us-east-1",
-    "consul_version": "1.0.0"
+    "consul_version": "1.2.2",
   },
   "builders": [{
     "name": "ubuntu16-ami",

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -3,6 +3,7 @@
   "variables": {
     "aws_region": "us-east-1",
     "consul_version": "1.2.2",
+    "download_url": ""
   },
   "builders": [{
     "name": "ubuntu16-ami",
@@ -50,7 +51,11 @@
   },{
     "type": "shell",
     "inline": [
-      "/tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}}",
+      "if [[ -n '{{user `download_url`}}' ]]; then",
+      " /tmp/terraform-aws-consul/modules/install-consul/install-consul --download-url {{user `download_url`}};",
+      "else",
+      " /tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}};",
+      "fi",
       "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"
     ],
     "pause_before": "30s"

--- a/modules/install-consul/README.md
+++ b/modules/install-consul/README.md
@@ -43,7 +43,8 @@ example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) 
 
 The `install-consul` script accepts the following arguments:
 
-* `version VERSION`: Install Consul version VERSION. Required. 
+* `version VERSION`: Install Consul version VERSION. Optional if download-url is provided.
+* `dowload-url URL`: Install the Consul package hosted in this url. Optional if version is provided.
 * `path DIR`: Install Consul into folder DIR. Optional.
 * `user USER`: The install dirs will be owned by user USER. Optional.
 * `ca-file-path PATH`: Path to a PEM-encoded certificate authority used to encrypt and verify authenticity of client and server connections. Optional.
@@ -53,7 +54,7 @@ The `install-consul` script accepts the following arguments:
 Example:
 
 ```
-install-consul --version 0.8.0
+install-consul --version 1.2.2
 ```
 
 
@@ -62,16 +63,16 @@ install-consul --version 0.8.0
 
 The `install-consul` script does the following:
 
-1. [Create a user and folders for Consul](#create-a-user-and-folders-for-consul)
-1. [Install Consul binaries and scripts](#install-consul-binaries-and-scripts)
-1. [Install provided TLS certificates](#install-tls-certificates)
-1. [Install supervisord](#install-supervisord)
+1. [Creates a user and folders for Consul](#create-a-user-and-folders-for-consul)
+1. [Installs Consul binaries and scripts](#install-consul-binaries-and-scripts)
+1. [Installs provided TLS certificates](#install-tls-certificates)
+1. [Installs supervisord](#install-supervisord)
 1. [Follow-up tasks](#follow-up-tasks)
 
 
-### Create a user and folders for Consul
+### Creates a user and folders for Consul
 
-Create an OS user named `consul`. Create the following folders, all owned by user `consul`:
+Creates an OS user named `consul`. Creates the following folders, all owned by user `consul`:
 
 * `/opt/consul`: base directory for Consul data (configurable via the `--path` argument).
 * `/opt/consul/bin`: directory for Consul binaries.
@@ -82,25 +83,26 @@ Create an OS user named `consul`. Create the following folders, all owned by use
 * `/opt/consul/tls/ca`: directory where an optional CA certificate is copied if provided.
 
 
-### Install Consul binaries and scripts
+### Installs Consul binaries and scripts
 
-Install the following:
+Installs the following:
 
-* `consul`: Download the Consul zip file from the [downloads page](https://www.consul.io/downloads.html) (the version 
-  number is configurable via the `--version` argument), and extract the `consul` binary into `/opt/consul/bin`. Add a
+* `consul`: Either downloads the Consul zip file from the [downloads page](https://www.consul.io/downloads.html) (the version
+  number is configurable via the `--version` argument), or a package hosted on a precise url configurable with `--dowload-url`
+  (useful for installing Consul Enterprise, for example) and extracts the `consul` binary into `/opt/consul/bin`. Adds a
   symlink to the `consul` binary in `/usr/local/bin`.
-* `run-consul`: Copy the [run-consul script](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul) into `/opt/consul/bin`. 
+* `run-consul`: Copies the [run-consul script](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul) into `/opt/consul/bin`.
 
-### Install TLS certificates
+### Installs TLS certificates
 
-Copy the certificates/key provided by the `--ca-file-path`, `cert-file-path` and `key-file-path` to the Consul
+Copies the certificates/key provided by the `--ca-file-path`, `cert-file-path` and `key-file-path` to the Consul
 configuration directory. If provided, the CA file is copied to `/opt/consul/tls/ca` and the server certificate/key
 are copied to `/opt/consul/tls` (assuming the default config path of `/opt/consul`). The script also sets the
 required permissions and file ownership.
 
-### Install supervisord
+### Installs supervisord
 
-Install [supervisord](http://supervisord.org/). We use it as a cross-platform supervisor to ensure Consul is started
+Installs [supervisord](http://supervisord.org/). We use it as a cross-platform supervisor to ensure Consul is started
 whenever the system boots and restarted if the Consul process crashes.
 
 

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -206,7 +206,7 @@ function fetch_binary {
   fi
 
   log_info "Downloading Consul from $download_url to $DOWNLOAD_PACKAGE_PATH"
-  curl -o "$DOWNLOAD_PACKAGE_PATH" "$download_url"
+  curl -o "$DOWNLOAD_PACKAGE_PATH" "$download_url" --location --silent --fail --show-error
 }
 
 function install_binary {

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -9,6 +9,7 @@ set -e
 
 readonly DEFAULT_INSTALL_PATH="/opt/consul"
 readonly DEFAULT_CONSUL_USER="consul"
+readonly DOWNLOAD_PACKAGE_PATH="/tmp/consul.zip"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SYSTEM_BIN_DIR="/usr/local/bin"
@@ -26,7 +27,8 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --version\t\tThe version of Consul to install. Required."
+  echo -e "  --version\t\tThe version of Consul to install. Optional if download-url is provided."
+  echo -e "  --download-url\t\tUrl to exact Consul package to be installed. Optional if version is provided."
   echo -e "  --path\t\tThe path where Consul should be installed. Optional. Default: $DEFAULT_INSTALL_PATH."
   echo -e "  --user\t\tThe user who will own the Consul install directories. Optional. Default: $DEFAULT_CONSUL_USER."
   echo -e "  --ca-file-path\t\tPath to a PEM-encoded certificate authority used to encrypt and verify authenticity of client and server connections. Will be installed under <install-path>/tls/ca."
@@ -35,7 +37,7 @@ function print_usage {
   echo
   echo "Example:"
   echo
-  echo "  install-consul --version 0.8.0"
+  echo "  install-consul --version 1.2.2"
 }
 
 function log {
@@ -66,6 +68,19 @@ function assert_not_empty {
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
+    print_usage
+    exit 1
+  fi
+}
+
+function assert_either_or {
+  local readonly arg1_name="$1"
+  local readonly arg1_value="$2"
+  local readonly arg2_name="$3"
+  local readonly arg2_value="$4"
+
+  if [[ -z "$arg1_value" && -z "$arg2_value" ]]; then
+    log_error "Either the value for '$arg1_name' or '$arg2_name' must be passed, both cannot be empty"
     print_usage
     exit 1
   fi
@@ -182,20 +197,27 @@ function create_consul_install_paths {
   sudo chown -R "$username:$username" "$path"
 }
 
-function install_binaries {
+function fetch_binary {
   local readonly version="$1"
-  local readonly path="$2"
-  local readonly username="$3"
+  local download_url="$2"
 
-  local readonly url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
-  local readonly download_path="/tmp/consul_${version}_linux_amd64.zip"
-  local readonly bin_dir="$path/bin"
+  if [[ -z "$download_url" && -n "$version" ]];  then
+    download_url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
+  fi
+
+  log_info "Downloading Consul from $download_url to $DOWNLOAD_PACKAGE_PATH"
+  curl -o "$DOWNLOAD_PACKAGE_PATH" "$download_url"
+}
+
+function install_binary {
+  local readonly install_path="$1"
+  local readonly username="$2"
+
+  local readonly bin_dir="$install_path/bin"
   local readonly consul_dest_path="$bin_dir/consul"
   local readonly run_consul_dest_path="$bin_dir/run-consul"
 
-  log_info "Downloading Consul $version from $url to $download_path"
-  curl -o "$download_path" "$url"
-  unzip -d /tmp "$download_path"
+  unzip -d /tmp "$DOWNLOAD_PACKAGE_PATH"
 
   log_info "Moving Consul binary to $consul_dest_path"
   sudo mv "/tmp/consul" "$consul_dest_path"
@@ -239,6 +261,7 @@ function install_tls_certificates {
 
 function install {
   local version=""
+  local download_url=""
   local path="$DEFAULT_INSTALL_PATH"
   local user="$DEFAULT_CONSUL_USER"
   local ca_file_path=""
@@ -251,6 +274,10 @@ function install {
     case "$key" in
       --version)
         version="$2"
+        shift
+        ;;
+      --download-url)
+        download_url="$2"
         shift
         ;;
       --path)
@@ -290,7 +317,7 @@ function install {
     shift
   done
 
-  assert_not_empty "--version" "$version"
+  assert_either_or "--version" "$version" "--download-url" "$download_url"
   assert_not_empty "--path" "$path"
   assert_not_empty "--user" "$user"
 
@@ -299,9 +326,11 @@ function install {
   install_dependencies
   create_consul_user "$user"
   create_consul_install_paths "$path" "$user"
-  install_binaries "$version" "$path" "$user"
 
-  if [[ ! -z "$ca_file_path" || ! -z "$cert_file_path" || ! -z "$key_file_path" ]]; then
+  fetch_binary "$version" "$download_url"
+  install_binary "$path" "$user"
+
+  if [[ -n "$ca_file_path" || -n "$cert_file_path" || -n "$key_file_path" ]]; then
     install_tls_certificates "$path" "$user" "$ca_file_path" "$cert_file_path" "$key_file_path"
   fi
 


### PR DESCRIPTION
* Allows passing an exact download url to the packer ami template and the install script. 
* Bumps the default consul version in the ami


@infosecgithub