### PR TITLE
Revert ami publishing changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ To deploy Consul servers using this Module:
    Here is an [example Packer template](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami#quick-start). 
    
    If you are just experimenting with this Module, you may find it more convenient to use one of our official public AMIs:
-   - **Latest Ubuntu 16 AMIs**: search for AMIs with names starting with `consul-ubuntu-` owned by account ID `562637147889`.
-   - **Latest Amazon Linux AMIs**: search for AMIs with names starting with `consul-amazon-linux-` owned by account ID `562637147889`.
-
+   - [Latest Ubuntu 16 AMIs](https://github.com/hashicorp/terraform-aws-consul/tree/master/_docs/ubuntu16-ami-list.md).
+   - [Latest Amazon Linux AMIs](https://github.com/hashicorp/terraform-aws-consul/tree/master/_docs/amazon-linux-ami-list.md).
+  
     **WARNING! Do NOT use these AMIs in your production setup. In production, you should build your own AMIs in your own 
     AWS account.**
    

--- a/_ci/publish-amis-in-new-account.md
+++ b/_ci/publish-amis-in-new-account.md
@@ -1,0 +1,26 @@
+# How to Publish AMIs in a New AWS Account
+
+This readme discusses how to migrate the `publish-amis.sh` script to a new AWS account.
+
+To make using this Module as easy as possible, we want to automatically build and publish AMIs based on the 
+[/examples/consul-ami/consul.json](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami/consul.json) Packer template upon every release of this repo. 
+This way, users can simply git clone this repo and `terraform apply` the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md)
+without first having to build their own AMI. Note that the auto-built AMIs are meant mostly for first-time users to 
+easily try out a Module. In a production setting, many users will want to validate the contents of their AMI by
+manually building it in their own account.
+
+Unfortunately, auto-building AMIs creates a chicken-and-egg problem. How can we run code that automatically finds the
+latest AMI until that AMI actually exists? But to build those AMIs, we have to run a build in CircleCI, which also runs
+automated tests, which will fail when they cannot find the desired AMI. 
+
+Our solution is that, for the `publish-amis` git branch only, on every commit, we will build and publish AMIs but we will
+not run tests. For all other branches, AMIs will only be built upon a new git tag (GitHub release), and tests will be
+run on every commit as usual. These settings are configured in the [circle.yml](https://github.com/hashicorp/terraform-aws-consul/tree/master/circle.yml) file.
+
+In addition to the above, don't forget to update the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment 
+variables in CircleCI to reflect the new AWS account.
+
+Finally, note that, on a brand new account, many AWS regions are limited to just 5 EC2 Instances in an Auto Scaling Group,
+but the automated tests in this repo create up to 10 EC2 Instances. Therefore, automated tests will fail if they run in
+a region with too small a limit. To avoid this issue, request an increase in the number of t2-family EC2 Instances 
+allowed in every AWS region from AWS support.

--- a/_ci/publish-amis.sh
+++ b/_ci/publish-amis.sh
@@ -26,8 +26,17 @@ if [[ -z "$PACKER_BUILD_NAME" ]]; then
   exit 1
 fi
 
+if [[ -z "$PUBLISH_AMI_AWS_ACCESS_KEY_ID" || -z "$PUBLISH_AMI_AWS_SECRET_ACCESS_KEY" ]]; then
+  echo "The PUBLISH_AMI_AWS_ACCESS_KEY_ID and PUBLISH_AMI_AWS_SECRET_ACCESS_KEY environment variables must be set to the AWS credentials to use to publish the AMIs."
+  exit 1
+fi
+
 echo "Checking out branch $BRANCH_NAME to make sure we do all work in a branch and not in detached HEAD state"
 git checkout "$BRANCH_NAME"
+
+# We publish the AMIs to a different AWS account, so set those credentials
+export AWS_ACCESS_KEY_ID="$PUBLISH_AMI_AWS_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$PUBLISH_AMI_AWS_SECRET_ACCESS_KEY"
 
 # Build the example AMI. WARNING! In a production setting, you should build your own AMI to ensure it has exactly the
 # configuration you want. We build this example AMI solely to make initial use of this Module as easy as possible.

--- a/_ci/publish-amis.sh
+++ b/_ci/publish-amis.sh
@@ -7,35 +7,51 @@
 
 set -e
 
-if [[ "$#" -ne 2 ]]; then
-  echo "Usage: publish-amis.sh PACKER_TEMPLATE_PATH BUILDER_NAME"
+readonly PACKER_TEMPLATE_PATH="/home/ubuntu/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json"
+readonly PACKER_TEMPLATE_DEFAULT_REGION="us-east-1"
+readonly AMI_PROPERTIES_FILE="/tmp/ami.properties"
+readonly AMI_LIST_MARKDOWN_DIR="/home/ubuntu/$CIRCLE_PROJECT_REPONAME/_docs"
+readonly GIT_COMMIT_MESSAGE="Add latest AMI IDs."
+readonly GIT_USER_NAME="gruntwork-ci"
+readonly GIT_USER_EMAIL="ci@gruntwork.io"
+
+# In CircleCI, every build populates the branch name in CIRCLE_BRANCH except builds triggered by a new tag, for which
+# the CIRCLE_BRANCH env var is empty. We assume tags are only issued against the master branch.
+readonly BRANCH_NAME="${CIRCLE_BRANCH:-master}"
+
+readonly PACKER_BUILD_NAME="$1"
+
+if [[ -z "$PACKER_BUILD_NAME" ]]; then
+  echo "ERROR: You must pass in the Packer build name as the first argument to this function."
   exit 1
 fi
 
-if [[ -z "$PUBLISH_AMI_AWS_ACCESS_KEY_ID" || -z "$PUBLISH_AMI_AWS_SECRET_ACCESS_KEY" ]]; then
-  echo "The PUBLISH_AMI_AWS_ACCESS_KEY_ID and PUBLISH_AMI_AWS_SECRET_ACCESS_KEY environment variables must be set to the AWS credentials to use to publish the AMIs."
-  exit 1
-fi
+echo "Checking out branch $BRANCH_NAME to make sure we do all work in a branch and not in detached HEAD state"
+git checkout "$BRANCH_NAME"
 
-readonly packer_template_path="$1"
-readonly builder_name="$2"
+# Build the example AMI. WARNING! In a production setting, you should build your own AMI to ensure it has exactly the
+# configuration you want. We build this example AMI solely to make initial use of this Module as easy as possible.
+build-packer-artifact \
+  --packer-template-path "$PACKER_TEMPLATE_PATH" \
+  --build-name "$PACKER_BUILD_NAME" \
+  --output-properties-file "$AMI_PROPERTIES_FILE"
 
-regions_response=$(aws ec2 describe-regions --region "us-east-1")
-all_aws_regions=$(echo "$regions_response" | jq -r '.Regions | map(.RegionName) | join(",")')
+# Copy the AMI to all regions and make it public in each
+source "$AMI_PROPERTIES_FILE"
+publish-ami \
+  --all-regions \
+  --source-ami-id "$ARTIFACT_ID" \
+  --source-ami-region "$PACKER_TEMPLATE_DEFAULT_REGION" \
+  --output-markdown > "$AMI_LIST_MARKDOWN_DIR/$PACKER_BUILD_NAME-list.md" \
+  --markdown-title-text "$PACKER_BUILD_NAME: Latest Public AMIs" \
+  --markdown-description-text "**WARNING! Do NOT use these AMIs in a production setting.** They are meant only to make
+    initial experiments with this module more convenient."
 
-echo "Building Packer template $packer_template_path (builder: $builder_name) and sharing it with all AWS accounts in the following regions: $all_aws_regions"
-
-# Copying AMIs to many regions can take longer than Packer's default wait timeouts, so we increase them here per
-# https://github.com/hashicorp/packer/issues/6536
-export AWS_MAX_ATTEMPTS=240
-export AWS_POLL_DELAY_SECONDS=15
-
-# We publish the AMIs to a different AWS account, so set those credentials
-export AWS_ACCESS_KEY_ID="$PUBLISH_AMI_AWS_ACCESS_KEY_ID"
-export AWS_SECRET_ACCESS_KEY="$PUBLISH_AMI_AWS_SECRET_ACCESS_KEY"
-
-packer build \
-  --only="$builder_name" \
-  -var copy_ami_to_regions="$all_aws_regions" \
-  -var share_ami_with_groups="all" \
-  "$packer_template_path"
+# Git add, commit, and push the newly created AMI IDs as a markdown doc to the repo
+git-add-commit-push \
+  --path "$AMI_LIST_MARKDOWN_DIR/$PACKER_BUILD_NAME-list.md" \
+  --message "$GIT_COMMIT_MESSAGE" \
+  --user-name "$GIT_USER_NAME" \
+  --user-email "$GIT_USER_EMAIL" \
+  --git-push-behavior "current" \
+  --branch-name "$BRANCH_NAME"

--- a/_docs/amazon-linux-ami-list.md
+++ b/_docs/amazon-linux-ami-list.md
@@ -1,0 +1,22 @@
+# amazon-linux-ami: Latest Public AMIs
+
+**WARNING! Do NOT use these AMIs in a production setting.** They are meant only to make
+    initial experiments with this module more convenient.
+
+| AWS Region | AMI ID |
+| ---------- | ------ |
+| ap-south-1 | ami-04238a3b4e34579e4 |
+| eu-west-3 | ami-08f71d5d25b5cf5ab |
+| eu-west-2 | ami-0f27942710a168390 |
+| eu-west-1 | ami-0d78cd8cb29c43b97 |
+| ap-northeast-2 | ami-0dc9fc2dbb4708333 |
+| ap-northeast-1 | ami-059aacbc2062a4c31 |
+| sa-east-1 | ami-00df1a246975ae9ea |
+| ca-central-1 | ami-096d6692ed63e4bf3 |
+| ap-southeast-1 | ami-0c6b7bf1bd28116fc |
+| ap-southeast-2 | ami-0b4b5fcb7fba0b831 |
+| eu-central-1 | ami-081b6375552502391 |
+| us-east-1 | ami-0cefe1c6ca6cb38f6 |
+| us-east-2 | ami-0d3d95eb01b632834 |
+| us-west-1 | ami-0264ee2b29e9013b7 |
+| us-west-2 | ami-041e5f2f7f70258d2 |

--- a/_docs/ubuntu16-ami-list.md
+++ b/_docs/ubuntu16-ami-list.md
@@ -1,0 +1,22 @@
+# ubuntu16-ami: Latest Public AMIs
+
+**WARNING! Do NOT use these AMIs in a production setting.** They are meant only to make
+    initial experiments with this module more convenient.
+
+| AWS Region | AMI ID |
+| ---------- | ------ |
+| ap-south-1 | ami-0816afb9d329f6519 |
+| eu-west-3 | ami-056c0a1d3b4fac990 |
+| eu-west-2 | ami-0f70476d8cb54c314 |
+| eu-west-1 | ami-06bcd55d3dbb30a2e |
+| ap-northeast-2 | ami-09509dc3d47d23ca7 |
+| ap-northeast-1 | ami-0ceea7d2792eac240 |
+| sa-east-1 | ami-041aaace4f751b9e3 |
+| ca-central-1 | ami-069f9b97957901019 |
+| ap-southeast-1 | ami-03d3aca3e97b75b18 |
+| ap-southeast-2 | ami-044a4d59df862bfbe |
+| eu-central-1 | ami-0fa9a66c79de34596 |
+| us-east-1 | ami-085df16e55e2c22d9 |
+| us-east-2 | ami-0d318e905761168c8 |
+| us-west-1 | ami-0405d1682e80f9d9f |
+| us-west-2 | ami-0252817ebd1ff7e64 |

--- a/circle.yml
+++ b/circle.yml
@@ -25,8 +25,6 @@ test:
 deployment:
   release:
     tag: /v.*/
-    # Packer pauses for a while with no build output. This prevents the build from being killed.
-    timeout: 1800
     commands:
       # If a new release is tagged in GitHub, build the AMIs and publish them to all regions.
       - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "/home/ubuntu/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json" "ubuntu16-ami"

--- a/circle.yml
+++ b/circle.yml
@@ -27,5 +27,13 @@ deployment:
     tag: /v.*/
     commands:
       # If a new release is tagged in GitHub, build the AMIs and publish them to all regions.
-      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "/home/ubuntu/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json" "ubuntu16-ami"
-      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "/home/ubuntu/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json" "amazon-linux-ami"
+      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "ubuntu16-ami"
+      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "amazon-linux-ami"
+
+    branch: publish-amis
+    commands:
+      # We generally only want to build AMIs on new releases, but when we are setting up AMIs in a new account for the
+      # first time, we want to build the AMIs but NOT run automated tests, since those tests will fail without an existing
+      # AMI already in the AWS Account.
+      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "ubuntu16-ami"
+      - ~/$CIRCLE_PROJECT_REPONAME/_ci/publish-amis.sh "amazon-linux-ami"

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -3,8 +3,6 @@
   "variables": {
     "aws_region": "us-east-1",
     "consul_version": "1.2.2",
-    "copy_ami_to_regions": "",
-    "share_ami_with_groups": "",
     "download_url": ""
   },
   "builders": [{
@@ -13,8 +11,6 @@
     "ami_description": "An Ubuntu 16.04 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
-    "ami_regions": "{{user `copy_ami_to_regions`}}",
-    "ami_groups": "{{user `share_ami_with_groups`}}",
     "type": "amazon-ebs",
     "source_ami_filter": {
       "filters": {
@@ -34,8 +30,6 @@
     "ami_description": "An Amazon Linux AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
-    "ami_regions": "{{user `copy_ami_to_regions`}}",
-    "ami_groups": "{{user `share_ami_with_groups`}}",
     "type": "amazon-ebs",
     "source_ami_filter": {
       "filters": {


### PR DESCRIPTION
In #77 I tried to simplify how we publish AMIs. While the code worked fine from my computer, it unfortunately would hang or pause for long periods of time in CircleCI with no log output, and the build would be terminated with the error "command XXX took more than 10 minutes since last output" (example: https://circleci.com/gh/hashicorp/terraform-aws-consul/89). 

I'm sure there's a way to work around this, but I don't have any more time to pour into this, so I'm reverting to the original AMI publishing code, and copying over just the credentials fix.