### PR TITLE
fix broken links to MAIN.md

### DIFF
--- a/_ci/publish-amis-in-new-account.md
+++ b/_ci/publish-amis-in-new-account.md
@@ -4,7 +4,7 @@ This readme discusses how to migrate the `publish-amis.sh` script to a new AWS a
 
 To make using this Module as easy as possible, we want to automatically build and publish AMIs based on the 
 [/examples/consul-ami/consul.json](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami/consul.json) Packer template upon every release of this repo. 
-This way, users can simply git clone this repo and `terraform apply` the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md)
+This way, users can simply git clone this repo and `terraform apply` the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster)
 without first having to build their own AMI. Note that the auto-built AMIs are meant mostly for first-time users to 
 easily try out a Module. In a production setting, many users will want to validate the contents of their AMI by
 manually building it in their own account.

--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -12,7 +12,7 @@ These AMIs will have [Consul](https://www.consul.io/) installed and configured t
 boot-up. They also have [Dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) installed and configured to use 
 Consul for DNS lookups of the `.consul` domain (e.g. `foo.service.consul`) (see [registering 
 services](https://www.consul.io/intro/getting-started/services.html) for instructions on how to register your services
-in Consul). To see how to deploy this AMI, check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md). 
+in Consul). To see how to deploy this AMI, check out the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster). 
 
 For more info on Consul installation and configuration, check out the 
 [install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) and [install-dnsmasq](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) documentation.
@@ -38,7 +38,7 @@ To build the Consul AMI:
 1. Run `packer build consul.json`.
 
 When the build finishes, it will output the IDs of the new AMIs. To see how to deploy one of these AMIs, check out the
-[consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md).
+[consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster).
 
 
 

--- a/examples/consul-examples-helper/README.md
+++ b/examples/consul-examples-helper/README.md
@@ -1,7 +1,7 @@
 # Consul Examples Helper
 
 This folder contains a helper script called `consul-examples-helper.sh` for working with the 
-[consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md). After running `terraform apply` on the example, if you run 
+[consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster). After running `terraform apply` on the example, if you run 
 `consul-examples-helper.sh`, it will automatically:
 
 1. Wait for the Consul server cluster to come up.

--- a/modules/consul-client-security-group-rules/README.md
+++ b/modules/consul-client-security-group-rules/README.md
@@ -3,7 +3,7 @@
 This folder contains a [Terraform](https://www.terraform.io/) module that defines the security group rules used by a 
 [Consul](https://www.consul.io/) client to control the traffic that is allowed to go in and out. 
 
-Normally, you'd get these rules by default if you're using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md), but if 
+Normally, you'd get these rules by default if you're using the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster), but if 
 you're running Consul on top of a different cluster, then you can use this module to add the necessary security group 
 rules to that cluster. For example, imagine you were using the [vault-cluster 
 module](https://github.com/hashicorp/terraform-aws-vault/tree/master/modules/vault-cluster) to run a cluster of 
@@ -44,4 +44,4 @@ Note the following parameters:
   
 You can find the other parameters in [variables.tf](variables.tf).
 
-Check out the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.
+Check out the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.

--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -55,7 +55,7 @@ Note the following parameters:
 
 You can find the other parameters in [variables.tf](variables.tf).
 
-Check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for fully-working sample code.
+Check out the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for fully-working sample code.
 
 
 
@@ -66,11 +66,11 @@ Check out the [consul-cluster example](https://github.com/hashicorp/terraform-aw
 
 If you want to connect to the cluster from your own computer, the easiest way is to use the [HTTP
 API](https://www.consul.io/docs/agent/http.html). Note that this only works if the Consul cluster is running in public
-subnets and/or your default VPC (as in the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md)), which is OK for testing
+subnets and/or your default VPC (as in the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster)), which is OK for testing
 and experimentation, but NOT recommended for production usage.
 
 To use the HTTP API, you first need to get the public IP address of one of the Consul Servers. You can find Consul
-servers by using AWS tags. If you're running the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md), the
+servers by using AWS tags. If you're running the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster), the
 [consul-examples-helper.sh script](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-examples-helper/consul-examples-helper.sh) will do the tag lookup
 for you automatically (note, you must have the [AWS CLI](https://aws.amazon.com/cli/),
 [jq](https://stedolan.github.io/jq/), and the [Consul agent](https://www.consul.io/) installed locally):

--- a/modules/consul-iam-policies/README.md
+++ b/modules/consul-iam-policies/README.md
@@ -44,4 +44,4 @@ Note the following parameters:
   
 You can find the other parameters in [variables.tf](variables.tf).
 
-Check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for working sample code.
+Check out the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.

--- a/modules/consul-security-group-rules/README.md
+++ b/modules/consul-security-group-rules/README.md
@@ -3,7 +3,7 @@
 This folder contains a [Terraform](https://www.terraform.io/) module that defines the security group rules used by a 
 [Consul](https://www.consul.io/) cluster to control the traffic that is allowed to go in and out of the cluster. 
 
-Normally, you'd get these rules by default if you're using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md), but if 
+Normally, you'd get these rules by default if you're using the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster), but if 
 you're running Consul on top of a different cluster, then you can use this module to add the necessary security group 
 rules to that cluster. For example, imagine you were using the [nomad-cluster 
 module](https://github.com/hashicorp/terraform-aws-nomad/tree/master/modules/nomad-cluster) to run a cluster of 
@@ -44,4 +44,4 @@ Note the following parameters:
   
 You can find the other parameters in [variables.tf](variables.tf).
 
-Check out the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.
+Check out the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for working sample code.

--- a/modules/install-consul/README.md
+++ b/modules/install-consul/README.md
@@ -3,7 +3,7 @@
 This folder contains a script for installing Consul and its dependencies. Use this script along with the
 [run-consul script](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul) to create a Consul [Amazon Machine Image 
 (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) that can be deployed in 
-[AWS](https://aws.amazon.com/) across an Auto Scaling Group using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster).
+[AWS](https://aws.amazon.com/) across an Auto Scaling Group using the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster).
 
 This script has been tested on the following operating systems:
 
@@ -33,8 +33,8 @@ join other nodes to form a cluster.
 We recommend running the `install-consul` script as part of a [Packer](https://www.packer.io/) template to create a
 Consul [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (see the 
 [consul-ami example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/consul-ami) for a fully-working sample code). You can then deploy the AMI across an Auto 
-Scaling Group using the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) (see the [main 
-example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for fully-working sample code).
+Scaling Group using the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) (see the [main 
+example](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for fully-working sample code).
 
 
 

--- a/modules/run-consul/README.md
+++ b/modules/run-consul/README.md
@@ -44,7 +44,7 @@ Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-dat
 when the EC2 Instance is first booting. After runing `run-consul` on that initial boot, the `supervisord` configuration 
 will automatically restart Consul if it crashes or the EC2 instance reboots.
 
-See the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/MAIN.md) for fully-working sample code.
+See the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster) for fully-working sample code.
 
 
 
@@ -172,7 +172,7 @@ Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that has th
 * `ec2:DescribeTags`
 * `autoscaling:DescribeAutoScalingGroups`
 
-These permissions are automatically added by the [consul-cluster module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster).
+These permissions are automatically added by the [consul-cluster](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-cluster).
 
 
 


### PR DESCRIPTION
```
$ ag -l MAIN.md | tee files_list.txt
_ci/publish-amis-in-new-account.md
examples/consul-examples-helper/README.md
examples/consul-ami/README.md
modules/consul-cluster/README.md
modules/install-consul/README.md
modules/consul-iam-policies/README.md
modules/run-consul/README.md
modules/consul-client-security-group-rules/README.md
modules/consul-security-group-rules/README.md
$ while read file; do sed -E -i '' -e 's/MAIN\.md/modules\/consul-cluster/g' -e 's!(\[consul-cluster) (module|example)!\1!g' "$file"; done < files_list.txt
$ rm files_list.txt

```