### PR TITLE
Switchable IAM

### DIFF
--- a/modules/consul-cluster/README.md
+++ b/modules/consul-cluster/README.md
@@ -257,6 +257,7 @@ docs](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-
 
 The IAM Role ARN is exported as an output variable if you need to add additional permissions.
 
+You can disable the creation of the IAM role and policies if needed by setting `enable_iam_setup` variable to false.  This allows you to create the role seperately from this module and supply the external role arn via the `iam_instance_profile_name` variable.
 
 
 ## How do you roll out updates?

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -186,8 +186,6 @@ resource "aws_iam_role" "instance_role" {
 }
 
 data "aws_iam_policy_document" "instance_role" {
-  count = "${var.enable_iam_setup}"
-
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -161,7 +161,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 
   name_prefix = "${var.cluster_name}"
   path        = "${var.instance_profile_path}"
-  role        = "${aws_iam_role.instance_role.name}"
+  role        = "${element(coalescelist(aws_iam_role.instance_role.*.name,list("")),0)}"
 
   # aws_launch_configuration.launch_configuration in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors

--- a/modules/consul-cluster/outputs.tf
+++ b/modules/consul-cluster/outputs.tf
@@ -11,11 +11,11 @@ output "launch_config_name" {
 }
 
 output "iam_role_arn" {
-  value = "${aws_iam_role.instance_role.arn}"
+  value = "${element(coalescelist(aws_iam_role.instance_role.*.arn,list("")),0)}"
 }
 
 output "iam_role_id" {
-  value = "${aws_iam_role.instance_role.id}"
+  value = "${element(coalescelist(aws_iam_role.instance_role.*.id,list("")),0)}"
 }
 
 output "security_group_id" {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -195,3 +195,13 @@ variable "tags" {
   type        = "list"
   default     = []
 }
+
+variable "enable_iam_setup" {
+  description = "If false, the IAM policy and role setup will be disabled.  This is to allow the IAM to be setup elsewhere if required."
+  default     = true
+}
+
+variable "iam_instance_profile_name" {
+  description = "If enable_iam_setup is false then this will be the name of the IAM instance profile to attach"
+  default     = ""
+}

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -197,7 +197,7 @@ variable "tags" {
 }
 
 variable "enable_iam_setup" {
-  description = "If false, the IAM policy and role setup will be disabled.  This is to allow the IAM to be setup elsewhere if required."
+  description = "If true, create the IAM Role, IAM Instance Profile, and IAM Policies. If false, these will not be created, and you can pass in your own IAM Instance Profile via var.iam_instance_profile_name."
   default     = true
 }
 

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_iam_role_policy" "auto_discover_cluster" {
+  count  = "${var.enabled}"
   name   = "auto-discover-cluster"
   role   = "${var.iam_role_id}"
   policy = "${data.aws_iam_policy_document.auto_discover_cluster.json}"

--- a/modules/consul-iam-policies/variables.tf
+++ b/modules/consul-iam-policies/variables.tf
@@ -7,7 +7,7 @@ variable "iam_role_id" {
   description = "The ID of the IAM Role to which these IAM policies should be attached"
 }
 
-variable "enabled" { 
+variable "enabled" {
   description = "Give the option to disable this module if required"
-  default = true
+  default     = true
 }

--- a/modules/consul-iam-policies/variables.tf
+++ b/modules/consul-iam-policies/variables.tf
@@ -6,3 +6,8 @@
 variable "iam_role_id" {
   description = "The ID of the IAM Role to which these IAM policies should be attached"
 }
+
+variable "enabled" { 
+  description = "Give the option to disable this module if required"
+  default = true
+}


### PR DESCRIPTION
Please review my PR that allows the IAM role and policy creation to be disabled.  This allows the role to be created externally and the ARN of the role to be supplied via tf variable.

This helps in situations where end users roles might not have the right to modify IAM but have the rights to deploy standard compute resources.

ref:
https://github.com/hashicorp/terraform-aws-consul/issues/42

I am afraid i am not very good with go so have not updated the tests but i am not in a situation currently where i can test with IAM enabled anyway so if someone could please confirm that all is good with this and merge it in, if not then please let me know.