### PR TITLE
Add dash at the end of name prefixes

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -11,7 +11,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_autoscaling_group" "autoscaling_group" {
-  name_prefix = "${var.cluster_name}"
+  name_prefix = "${var.cluster_name}-"
 
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
 
@@ -85,7 +85,7 @@ resource "aws_launch_configuration" "launch_configuration" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_security_group" "lc_security_group" {
-  name_prefix = "${var.cluster_name}"
+  name_prefix = "${var.cluster_name}-"
   description = "Security group for the ${var.cluster_name} launch configuration"
   vpc_id      = "${var.vpc_id}"
 
@@ -158,7 +158,7 @@ module "security_group_rules" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_iam_instance_profile" "instance_profile" {
-  name_prefix = "${var.cluster_name}"
+  name_prefix = "${var.cluster_name}-"
   path        = "${var.instance_profile_path}"
   role        = "${aws_iam_role.instance_role.name}"
 
@@ -171,7 +171,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 }
 
 resource "aws_iam_role" "instance_role" {
-  name_prefix        = "${var.cluster_name}"
+  name_prefix        = "${var.cluster_name}-"
   assume_role_policy = "${data.aws_iam_policy_document.instance_role.json}"
 
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means


### PR DESCRIPTION
to align them between all resources.