### PR TITLE
Add variable for ASG service role

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -27,6 +27,7 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   health_check_type         = "${var.health_check_type}"
   health_check_grace_period = "${var.health_check_grace_period}"
   wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+  service_linked_role_arn   = "${var.service_linked_role_arn}"
 
   tags = [
     {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -145,6 +145,11 @@ variable "wait_for_capacity_timeout" {
   default     = "10m"
 }
 
+variable "service_linked_role_arn" {
+  description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
+  default     = ""
+}
+
 variable "health_check_type" {
   description = "Controls how health checking is done. Must be one of EC2 or ELB."
   default     = "EC2"


### PR DESCRIPTION
* When not specified; the created ASG will use the default AWS Service
  Role for Auto Scaling for performing AWS API calls such as
  RunInstances.
* This change allows the caller to specify a custom ASG role by passing
  role ARN and as such allowing custom permissions such as access to a
  KMS key for encrypted AMIs
* By defaulting to empty the aws provider will use the default role