### PR TITLE
Fix broken test for custom ASG service-linked role

### DIFF
--- a/examples/example-with-custom-asg-role/main.tf
+++ b/examples/example-with-custom-asg-role/main.tf
@@ -17,7 +17,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_iam_service_linked_role" "consul_asg_role" {
   aws_service_name = "autoscaling.amazonaws.com"
-  custom_suffix    = "${format("consul-slr-%s",replace(replace(timestamp(),"-",""),":",""))}"
+  custom_suffix    = "${var.consul_service_linked_role_suffix}"
   description      = "Service-Linked Role enables access to AWS Services and Resources used or managed by Auto Scaling"
 }
 

--- a/examples/example-with-custom-asg-role/main.tf
+++ b/examples/example-with-custom-asg-role/main.tf
@@ -17,7 +17,7 @@ terraform {
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_iam_service_linked_role" "consul_asg_role" {
   aws_service_name = "autoscaling.amazonaws.com"
-  custom_suffix    = "test-consul-service-linked-role"
+  custom_suffix    = "${format("consul-slr-%s",replace(replace(timestamp(),"-",""),":",""))}"
   description      = "Service-Linked Role enables access to AWS Services and Resources used or managed by Auto Scaling"
 }
 

--- a/examples/example-with-custom-asg-role/variables.tf
+++ b/examples/example-with-custom-asg-role/variables.tf
@@ -81,3 +81,8 @@ variable "key_file_path" {
   description = "Path to the certificate key used to verify incoming connections."
   default = "/opt/consul/tls/consul.key.pem"
 }
+
+variable "consul_service_linked_role_suffix" {
+  description = "Suffix for the aws_iam_service_linked_role created for the consul cluster auto scaling group to use"
+  default = "test-consul-service-linked-role"
+}

--- a/test/consul_cluster_with_custom_asg_role_test.go
+++ b/test/consul_cluster_with_custom_asg_role_test.go
@@ -1,13 +1,22 @@
 package test
 
-import "testing"
+import (
+	"testing"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
 
 func TestConsulClusterWithCustomASGRoleUbuntuAmi(t *testing.T) {
 	t.Parallel()
-	runConsulClusterTest(t, "ubuntu16-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ubuntu", "")
+	terraformVars := map[string]interface{}{
+		"consul_service_linked_role_suffix": random.UniqueId(),
+	}
+	runConsulClusterTestWithVars(t, "ubuntu16-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ubuntu", terraformVars, "")
 }
 
 func TestConsulClusterWithCustomASGRoleAmazonLinuxAmi(t *testing.T) {
 	t.Parallel()
-	runConsulClusterTest(t, "amazon-linux-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ec2-user", "")
+	terraformVars := map[string]interface{}{
+		"consul_service_linked_role_suffix": random.UniqueId(),
+	}
+	runConsulClusterTestWithVars(t, "amazon-linux-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ec2-user", terraformVars, "")
 }


### PR DESCRIPTION
* Test did not account for the role already existing
* Adds timestamp to role name to make unique
* Due to limits in the AWS role name length the uuid function won't work
* Due to limits in the AWS role name supported characters it has to do
  some funky replace statements on the timestamp