### PR TITLE
Add parameter for specifying count of allowed_ssh_security_group_ids

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -114,7 +114,7 @@ resource "aws_security_group_rule" "allow_ssh_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_ssh_inbound_from_security_group_ids" {
-  count                    = "${length(var.allowed_ssh_security_group_ids)}"
+  count                    = "${var.allowed_ssh_security_group_count}"
   type                     = "ingress"
   from_port                = "${var.ssh_port}"
   to_port                  = "${var.ssh_port}"

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -77,6 +77,11 @@ variable "allowed_ssh_security_group_ids" {
   default     = []
 }
 
+variable "allowed_ssh_security_group_count" {
+  description = "The number of entries in var.allowed_ssh_security_group_ids. Ideally, this value could be computed dynamically, but we pass this variable to a Terraform resource's 'count' property and Terraform requires that 'count' be computed with literals or data sources only."
+  default     = 0
+}
+
 variable "allowed_inbound_security_group_ids" {
   description = "A list of security group IDs that will be allowed to connect to Consul"
   type        = "list"


### PR DESCRIPTION
Address the error:

    Error: Error running plan: 1 error(s) occurred:

    * module.consul-servers.aws_security_group_rule.allow_ssh_inbound_from_security_group_ids: aws_security_group_rule.allow_ssh_inbound_from_security_group_ids: value of 'count' cannot be computed

This is a known limitation of the Terraform API. Hard-coding the value is the only currently available solution.