### PR TITLE
update default num servers and clients

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -24,12 +24,12 @@ variable "cluster_name" {
 
 variable "num_servers" {
   description = "The number of Consul server nodes to deploy. We strongly recommend using 3 or 5."
-  default     = 3
+  default     = 5
 }
 
 variable "num_clients" {
   description = "The number of Consul client nodes to deploy. You typically run the Consul client alongside your apps, so set this value to however many Instances make sense for your app code."
-  default     = 6
+  default     = 0
 }
 
 variable "cluster_tag_key" {


### PR DESCRIPTION
This is a PR to update the default number of consul servers to 5 as per the hashicorp Reference Architecture and to set the default number of clients to 0