### PR TITLE
Fix ami publishing and add nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,10 @@ jobs:
     steps:
       - checkout
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-      - run: gruntwork-install --module-name "aws-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
-      - run: gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
-      - run: gruntwork-install --module-name "build-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
+      - run: sudo -E gruntwork-install --module-name "aws-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
+      - run: sudo -E gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
+      - run: sudo -E gruntwork-install --module-name "build-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.12.2"
+
       # We generally only want to build AMIs on new releases, but when we are setting up AMIs in a new account for the
       # first time, we want to build the AMIs but NOT run automated tests, since those tests will fail without an existing
       # AMI already in the AWS Account.
@@ -63,18 +64,31 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-    - build
-    - test:
-        requires:
-        - build
-        filters:
-          branches:
-            ignore: publish-amis
-    - deploy:
-        requires:
-        - build
-        filters:
-          tags:
-            only: /^v.*/
-          branches:
-            only: publish-amis
+      - build
+      - test:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: publish-amis
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: publish-amis
+            tags:
+              only: /^v.*/
+  nightly-test:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build
+      - test:
+          requires:
+            - build

--- a/_ci/publish-amis.sh
+++ b/_ci/publish-amis.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 #
-# Build the example AMI, copy it to all AWS regions, and make all AMIs public. 
+# Build the example AMI, copy it to all AWS regions, and make all AMIs public.
 #
 # This script is meant to be run in a CircleCI job.
 #
 
 set -e
 
-readonly PACKER_TEMPLATE_PATH="/home/ubuntu/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json"
+readonly PACKER_TEMPLATE_PATH="/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json"
 readonly PACKER_TEMPLATE_DEFAULT_REGION="us-east-1"
 readonly AMI_PROPERTIES_FILE="/tmp/ami.properties"
-readonly AMI_LIST_MARKDOWN_DIR="/home/ubuntu/$CIRCLE_PROJECT_REPONAME/_docs"
+readonly AMI_LIST_MARKDOWN_DIR="/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/_docs"
 readonly GIT_COMMIT_MESSAGE="Add latest AMI IDs."
 readonly GIT_USER_NAME="gruntwork-ci"
 readonly GIT_USER_EMAIL="ci@gruntwork.io"


### PR DESCRIPTION
It works as seen on https://circleci.com/gh/hashicorp/terraform-aws-consul/tree/publish-amis

Additionally, "gruntwork-ci" github user needed access to this repo so it could publish the markdown with the resulting amis