### PR TITLE
Add UUID to AMI names

### DIFF
--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -7,7 +7,7 @@
   },
   "builders": [{
     "name": "ubuntu16-ami",
-    "ami_name": "consul-ubuntu-{{isotime | clean_ami_name}}",
+    "ami_name": "consul-ubuntu-{{isotime | clean_ami_name}}-{{uuid}}",
     "ami_description": "An Ubuntu 16.04 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
@@ -26,7 +26,7 @@
     "ssh_username": "ubuntu"
   },{
     "name": "amazon-linux-2-ami",
-    "ami_name": "consul-amazon-linux-2-{{isotime | clean_ami_name}}",
+    "ami_name": "consul-amazon-linux-2-{{isotime | clean_ami_name}}-{{uuid}}",
     "ami_description": "An Amazon Linux 2 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",

--- a/examples/example-with-encryption/packer/consul-with-certs.json
+++ b/examples/example-with-encryption/packer/consul-with-certs.json
@@ -8,7 +8,7 @@
     "tls_private_key_path": "{{template_dir}}/consul.key.pem"
   },
   "builders": [{
-    "ami_name": "consul-with-encryption-ubuntu-{{isotime | clean_ami_name}}",
+    "ami_name": "consul-with-encryption-ubuntu-{{isotime | clean_ami_name}}-{{uuid}}",
     "ami_description": "An Ubuntu 16.04 AMI that has Consul installed and TLS certificates.",
     "instance_type": "t2.micro",
     "name": "ubuntu16-ami",
@@ -27,7 +27,7 @@
     },
     "ssh_username": "ubuntu"
   },{
-    "ami_name": "consul-with-encryption-amazon-linux-2-{{isotime | clean_ami_name}}",
+    "ami_name": "consul-with-encryption-amazon-linux-2-{{isotime | clean_ami_name}}-{{uuid}}",
     "ami_description": "An Amazon Linux 2 AMI that has Consul installed and TLS certificates.",
     "instance_type": "t2.micro",
     "name": "amazon-linux-2-ami",


### PR DESCRIPTION
We are getting `Error creating AMI: InvalidAMIName.Duplicate: AMI name consul-ubuntu-2019-03-29T12-28-48Z is already in use by AMI ami-0f589d96558469b10` style errors in tests. Hopefully this will fix it.