### PR TITLE
Enable systemd consul service

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -383,6 +383,7 @@ function start_consul {
   sudo systemctl daemon-reload
   sudo systemctl enable consul.service
   sudo systemctl restart consul.service
+
 }
 
 # Based on: http://unix.stackexchange.com/a/7732/215969

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -381,6 +381,7 @@ function start_consul {
   log_info "Reloading systemd config and starting Consul"
 
   sudo systemctl daemon-reload
+  sudo systemctl enable consul.service
   sudo systemctl restart consul.service
 }
 


### PR DESCRIPTION
To make sure that consul service will automatically start after a server reboot it has to be enabled so that systemd will know to autostart it during boot sequence. 