### PR TITLE
Enable systemd consul service

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -381,6 +381,7 @@ function start_consul {
   log_info "Reloading systemd config and starting Consul"
 
   sudo systemctl daemon-reload
+  sudo systemctl enable consul.service
   sudo systemctl restart consul.service
 }
 


### PR DESCRIPTION
To make sure that consul service will automatically start after a server reboot it has to be enabled so that systemd will know to autostart it during boot sequence.