### PR TITLE
Add --recursor option for run-consul script

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -53,6 +53,7 @@ function print_usage {
   echo -e "  --key-file-path\tPath to the certificate key used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --cert-file-path."
   echo -e "  --environment\t\tA single environment variable in the key/value pair form 'KEY=\"val\"' to pass to Consul as environment variable when starting it up. Repeat this option for additional variables. Optional."
   echo -e "  --skip-consul-config\tIf this flag is set, don't generate a Consul configuration file. Optional. Default is false."
+  echo -e "  --recursor\tThis flag provides address of upstream DNS server that is used to recursively resolve queries if they are not inside the service domain for Consul. Repeat this option for additional variables. Optional."
   echo
   echo "Options for Consul Autopilot:"
   echo
@@ -232,6 +233,9 @@ function generate_consul_config {
   local -r upgrade_version_tag=${19}
   local -r config_path="$config_dir/$CONSUL_CONFIG_FILE"
 
+  shift 19
+  local -r recursors=("$@")
+
   local instance_id=""
   local instance_ip_address=""
   local instance_region=""
@@ -249,6 +253,16 @@ function generate_consul_config {
 "retry_join": ["provider=aws region=$instance_region tag_key=$cluster_tag_key tag_value=$cluster_tag_value"],
 EOF
 )
+  fi
+
+  local recursors_config=""
+  if (( ${#recursors[@]} != 0 )); then
+        recursors_config="\"recursors\" : [ "
+        for recursor in ${recursors[@]}
+        do
+            recursors_config="${recursors_config}\"${recursor}\", "
+        done
+        recursors_config=$(echo "${recursors_config}"| sed 's/, $//')" ],"
   fi
 
   local bootstrap_expect=""
@@ -304,6 +318,7 @@ EOF
   "client_addr": "0.0.0.0",
   "datacenter": "$datacenter",
   "node_name": "$instance_id",
+  $recursors_config
   $retry_join_json
   "server": $server,
   $gossip_encryption_configuration
@@ -412,6 +427,7 @@ function run {
   local key_file_path=""
   local environment=()
   local skip_consul_config="false"
+  local recursors=()
   local all_args=()
   local cleanup_dead_servers="$DEFAULT_AUTOPILOT_CLEANUP_DEAD_SERVERS"
   local last_contact_threshold="$DEFAULT_AUTOPILOT_LAST_CONTACT_THRESHOLD"
@@ -543,6 +559,11 @@ function run {
       --skip-consul-config)
         skip_consul_config="true"
         ;;
+      --recursor)
+        assert_not_empty "$key" "$2"
+        recursors+=("$2")
+        shift
+        ;;
       --help)
         print_usage
         exit
@@ -619,7 +640,8 @@ function run {
       "$server_stabilization_time" \
       "$redundancy_zone_tag" \
       "$disable_upgrade_migration" \
-      "$upgrade_version_tag"
+      "$upgrade_version_tag" \
+      "${recursors[@]}"
   fi
 
   generate_systemd_config "$SYSTEMD_CONFIG_PATH" "$config_dir" "$data_dir" "$systemd_stdout" "$systemd_stderr" "$bin_dir" "$user" "${environment[@]}"


### PR DESCRIPTION
In order to be able to add recursors servers to consul config (https://www.consul.io/docs/agent/options.html#recursors) a new parameter needs to be added to run-consul script.
It is useful when you also install dnsmasq and want to recursively resolve queries that are not inside the consul service domain.
Another example could be if you want to access a private EKS API endpoint from an on-premise network connected through AWS Direct Connect (DX) or a virtual private network (VPN) to EKS VPC.