### PR TITLE
Prevent packer from catching SQL server specific ami

### DIFF
--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -37,7 +37,8 @@
         "architecture": "x86_64",
         "name": "*amzn2-ami-hvm-*",
         "block-device-mapping.volume-type": "gp2",
-        "root-device-type": "ebs"
+        "root-device-type": "ebs",
+        "owner-id":"137112412989"
       },
       "owners": ["amazon"],
       "most_recent": true


### PR DESCRIPTION
Nightly builds started flagging 13 days ago that all amazon linux tests were failing

This was the culprit
<img width="1132" alt="Screen Shot 2019-05-29 at 18 01 12" src="https://user-images.githubusercontent.com/1516418/58576453-49d73500-823c-11e9-846e-6e3126736b20.png">
