### PR TITLE
Specify Type notify on systemd service

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -360,6 +360,7 @@ EOF
 
   local -r service_config=$(cat <<EOF
 [Service]
+Type=notify
 User=$consul_user
 Group=$consul_user
 ExecStart=$consul_bin_dir/consul agent -config-dir $consul_config_dir -data-dir $consul_data_dir


### PR DESCRIPTION
Hey there- thanks for this module!

We've been noticing a race condition wherein our application, which depends on having joined the Consul cluster, starts up _after_ Consul has started but _before_ the cluster has been joined. 

We are using systemd service configurations for both Consul and our application, which explicitly defines `Requires=consul.service` and `After=consul.service`. Because the `consul.service` Unit file written by this module has no Type specified, it defaults to `simple`, so systemd considers the service "active (running)" as soon as the task is started.

I saw [this PR on the Consul library](https://github.com/hashicorp/consul/pull/5689) itself, and thought that this module probably wants to be updated too, since others (like us) are using this to configure remote machines to join a Consul cluster.

Thanks!