### PR TITLE
Increase timeout on systemd config

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -367,6 +367,7 @@ ExecStart=$consul_bin_dir/consul agent -config-dir $consul_config_dir -data-dir 
 ExecReload=$consul_bin_dir/consul reload
 KillMode=process
 Restart=on-failure
+TimeoutSec=300s
 LimitNOFILE=65536
 $(split_by_lines "Environment=" "${environment[@]}")
 


### PR DESCRIPTION
After #146, systemd now waits for consul's notification of having joined the cluster before signaling that the service is alive. This however may occasionally result in larger waiting times and intermittent timeout failures.

The following error was observed in the [terraform-aws-vault](https://github.com/hashicorp/terraform-aws-vault) logs: `Job for consul.service failed because a timeout was exceeded. See "systemctl status consul.service" and "journalctl -xe" for details.`

As a remedy, this PR raises the timeout from 90s (the default) to a more reasonable 300s.