### PR TITLE
Set defaults for allowed_inbound_cidr_blocks

### DIFF
--- a/modules/consul-client-security-group-rules/variables.tf
+++ b/modules/consul-client-security-group-rules/variables.tf
@@ -10,6 +10,7 @@ variable "security_group_id" {
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Consul"
   type        = list(string)
+  default     = []
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-security-group-rules/variables.tf
+++ b/modules/consul-security-group-rules/variables.tf
@@ -11,6 +11,7 @@ variable "security_group_id" {
 variable "allowed_inbound_cidr_blocks" {
   description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections to Consul"
   type        = list(string)
+  default     = []
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
These variables don't necessarily have to be set to anything and leaving
them empty can work just fine due to the security groups allowing
"self".  As such setting them to an empty list avoids extra rules being
put in place.