### PR TITLE
Add support for enabling auto_encrypt on both server and client instances

### DIFF
--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -51,6 +51,7 @@ function print_usage {
   echo -e "  --ca-path\t\tPath to the directory of CA files used to verify outgoing connections. Optional. Must be specified with --enable-rpc-encryption."
   echo -e "  --cert-file-path\tPath to the certificate file used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --key-file-path."
   echo -e "  --key-file-path\tPath to the certificate key used to verify incoming connections. Optional. Must be specified with --enable-rpc-encryption and --cert-file-path."
+  echo -e "  --enable-auto-encryption\t\tEnable auto_encrypt setting for servers and clients."
   echo -e "  --environment\t\tA single environment variable in the key/value pair form 'KEY=\"val\"' to pass to Consul as environment variable when starting it up. Repeat this option for additional variables. Optional."
   echo -e "  --skip-consul-config\tIf this flag is set, don't generate a Consul configuration file. Optional. Default is false."
   echo -e "  --recursor\tThis flag provides address of upstream DNS server that is used to recursively resolve queries if they are not inside the service domain for Consul. Repeat this option for additional variables. Optional."
@@ -231,9 +232,10 @@ function generate_consul_config {
   local -r redundancy_zone_tag="${17}"
   local -r disable_upgrade_migration="${18}"
   local -r upgrade_version_tag=${19}
+  local -r enable_auto_encryption="${20}"
   local -r config_path="$config_dir/$CONSUL_CONFIG_FILE"
 
-  shift 19
+  shift 20
   local -r recursors=("$@")
 
   local instance_id=""
@@ -302,11 +304,39 @@ EOF
     rpc_encryption_configuration=$(cat <<EOF
 "verify_outgoing": true,
 "verify_incoming": true,
+"verify_incoming_https": false,
+"verify_server_hostname": true,
+"enable_agent_tls_for_checks": true,
 "ca_path": "$ca_path",
 "cert_file": "$cert_file_path",
 "key_file": "$key_file_path",
+"ports": {
+  "https": 8501,
+  "grpc": 8502
+},
 EOF
 )
+  fi
+
+  local auto_encrypt_configuration=""
+  if [[ "$enable_auto_encryption" == "true" ]]; then
+    if [[ "$server" == "true" ]]; then
+      log_info "Creating RPC auto_encrypt configuration for server"
+      auto_encrypt_configuration=$(cat <<EOF
+"auto_encrypt": {
+    "allow_tls": true
+},
+EOF
+)
+    else
+      log_info "Creating RPC auto_encrypt configuration for client"
+      auto_encrypt_configuration=$(cat <<EOF
+"auto_encrypt": {
+    "tls": true
+},
+EOF
+)
+    fi
   fi
 
   log_info "Creating default Consul configuration"
@@ -323,6 +353,7 @@ EOF
   "server": $server,
   $gossip_encryption_configuration
   $rpc_encryption_configuration
+  $auto_encrypt_configuration
   $autopilot_configuration
   "ui": $ui
 }
@@ -553,6 +584,9 @@ function run {
         key_file_path="$2"
         shift
         ;;
+      --enable-auto-encryption)
+        enable_auto_encryption="true"
+        ;;
       --environment)
         assert_not_empty "$key" "$2"
         environment+=("$2")
@@ -643,6 +677,7 @@ function run {
       "$redundancy_zone_tag" \
       "$disable_upgrade_migration" \
       "$upgrade_version_tag" \
+      "$enable_auto_encryption" \
       "${recursors[@]}"
   fi
 

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -339,6 +339,13 @@ EOF
     "http": -1,
     "https": 8501
 },
+"connect": {
+  "enabled": true,
+  "ca_config": {
+    "private_key_type": "ec",
+    "private_key_bits": 256
+  }
+},
 EOF
 )
     fi

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -331,8 +331,13 @@ EOF
     else
       log_info "Creating RPC auto_encrypt configuration for client"
       auto_encrypt_configuration=$(cat <<EOF
+"ca_file": "$ca_path",
 "auto_encrypt": {
     "tls": true
+},
+"ports": {
+    "http": -1,
+    "https": 8501
 },
 EOF
 )

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -336,8 +336,11 @@ EOF
     "tls": true
 },
 "ports": {
-    "http": -1,
+    "http": 8500,
     "https": 8501
+},
+"http_config": {
+    "allow_write_http_from": ["127.0.0.0/8"]
 },
 "connect": {
   "enabled": true,


### PR DESCRIPTION
We get support for enabling auto_encryption at set up time, allowing client instances to get their TLS key/cert pairs from the consul servers.

In order to allow browsers to access the UI we also need to enable the HTTPS endpoint and disable mTLS on the HTTPS endponit, while keeping mTLS enabled for RPC connections.

There are a couple of special cases to be considered (see individual commits for details):

1. Workaround for v1.6.0 (hashicorp/consul#6391)
2. Workaround lack of support for HTTPS (hashicorp/consul#6403)