### PR TITLE
Don't install dnsmasq on ubuntu18

### DIFF
--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -80,7 +80,6 @@
       "else",
       " /tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}};",
       "fi",
-      "/tmp/terraform-aws-consul/modules/install-dnsmasq/install-dnsmasq"
     ],
     "pause_before": "30s"
   },{

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -79,7 +79,7 @@
       " /tmp/terraform-aws-consul/modules/install-consul/install-consul --download-url {{user `download_url`}};",
       "else",
       " /tmp/terraform-aws-consul/modules/install-consul/install-consul --version {{user `consul_version`}};",
-      "fi",
+      "fi"
     ],
     "pause_before": "30s"
   },{


### PR DESCRIPTION
This fixes the AMI example so that dnsmasq installation step is skipped for Ubuntu 18.