### PR TITLE
listen on 0.0.0.0 instead of

### DIFF
--- a/modules/install-dnsmasq/install-dnsmasq
+++ b/modules/install-dnsmasq/install-dnsmasq
@@ -106,7 +106,7 @@ function write_consul_config {
 # Enable forward lookup of the '$consul_domain' domain:
 server=/${consul_domain}/${consul_ip}#${consul_port}
 
-listen-address=${consul_ip}
+listen-address=0.0.0.0
 bind-interfaces
 EOF
 }


### PR DESCRIPTION
Fix dnsmasq configuration so that it listens on `0.0.0.0` instead of `$consul_ip`, which by default, is `127.0.0.1`.

I believe the intention here is to allow dnsmasq to accept inbound requests on the default interface, not just your local loopback.

This matters because if you run a docker container on a VM you installed dnsmasq on, you won't be able to target the dnsmasq server if it's listening on `127.0.0.1`.
