### PR TITLE
s/clean_ami_name/clean_resource_name/

### DIFF
--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -1,5 +1,5 @@
 {
-  "min_packer_version": "0.12.0",
+  "min_packer_version": "1.5.4",
   "variables": {
     "aws_region": "us-east-1",
     "consul_version": "1.5.1",

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -7,7 +7,7 @@
   },
   "builders": [{
     "name": "ubuntu16-ami",
-    "ami_name": "consul-ubuntu-{{isotime | clean_ami_name}}-{{uuid}}",
+    "ami_name": "consul-ubuntu-{{isotime | clean_resource_name}}-{{uuid}}",
     "ami_description": "An Ubuntu 16.04 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
@@ -26,7 +26,7 @@
     "ssh_username": "ubuntu"
   },{
     "name": "ubuntu18-ami",
-    "ami_name": "consul-ubuntu-{{isotime | clean_ami_name}}-{{uuid}}",
+    "ami_name": "consul-ubuntu-{{isotime | clean_resource_name}}-{{uuid}}",
     "ami_description": "An Ubuntu 18.04 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
@@ -46,7 +46,7 @@
     "ssh_username": "ubuntu"
   },{
     "name": "amazon-linux-2-ami",
-    "ami_name": "consul-amazon-linux-2-{{isotime | clean_ami_name}}-{{uuid}}",
+    "ami_name": "consul-amazon-linux-2-{{isotime | clean_resource_name}}-{{uuid}}",
     "ami_description": "An Amazon Linux 2 AMI that has Consul installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",


### PR DESCRIPTION
Fixes: #170 
`clean_ami_name1 has been replaced by `clean_resource_name` in  packer v1.4. Updated `consul.json` to reflect this. 

Ref: https://github.com/hashicorp/packer/pull/7456