### PR TITLE
Add consul snapshot flags (Consul enterprise)

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -223,9 +223,10 @@ data "aws_iam_policy_document" "instance_role" {
 module "iam_policies" {
   source = "../consul-iam-policies"
 
-  enabled               = var.enable_iam_setup
-  enable_snapshot_agent = var.enable_snapshot_agent
-  snapshot_agent_bucket = var.snapshot_agent_bucket
-  iam_role_id           = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
+  enabled                    = var.enable_iam_setup
+  enable_snapshot_agent      = var.enable_snapshot_agent
+  snapshot_agent_bucket      = var.snapshot_agent_bucket
+  snapshot_agent_bucket_path = var.snapshot_agent_bucket_path
+  iam_role_id                = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
 }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -223,10 +223,10 @@ data "aws_iam_policy_document" "instance_role" {
 module "iam_policies" {
   source = "../consul-iam-policies"
 
-  enabled                    = var.enable_iam_setup
-  enable_snapshot_agent      = var.enable_snapshot_agent
-  snapshot_agent_bucket      = var.snapshot_agent_bucket
-  snapshot_agent_bucket_path = var.snapshot_agent_bucket_path
-  iam_role_id                = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
+  enabled                      = var.enable_iam_setup
+  enable_snapshot_agent        = var.enable_snapshot_agent
+  snapshot_agent_bucket        = var.snapshot_agent_bucket
+  snapshot_agent_s3_key_prefix = var.snapshot_agent_s3_key_prefix
+  iam_role_id                  = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
 }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -223,7 +223,9 @@ data "aws_iam_policy_document" "instance_role" {
 module "iam_policies" {
   source = "../consul-iam-policies"
 
-  enabled     = var.enable_iam_setup
-  iam_role_id = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
+  enabled               = var.enable_iam_setup
+  enable_snapshot_agent = var.enable_snapshot_agent
+  snapshot_agent_bucket = var.snapshot_agent_bucket
+  iam_role_id           = element(concat(aws_iam_role.instance_role.*.id, [""]), 0)
 }
 

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -271,3 +271,9 @@ variable "snapshot_agent_bucket" {
   type        = string
   default     = null
 }
+
+variable "snapshot_agent_bucket_path" {
+  description = "(Consul Enterprise only) The path within the s3 bucket that the snapshot agent writes to.  Defaults to consul-snapshot."
+  type        = string
+  default     = "consul-snapshot"
+}

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -272,8 +272,8 @@ variable "snapshot_agent_bucket" {
   default     = null
 }
 
-variable "snapshot_agent_bucket_path" {
-  description = "(Consul Enterprise only) The path within the s3 bucket that the snapshot agent writes to.  Defaults to consul-snapshot."
+variable "snapshot_agent_s3_key_prefix" {
+  description = "(Consul Enterprise only) The path prefix within the s3 bucket that the snapshot agent writes to.  Defaults to consul-snapshot."
   type        = string
   default     = "consul-snapshot"
 }

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -260,3 +260,14 @@ variable "iam_instance_profile_name" {
   default     = null
 }
 
+variable "enable_snapshot_agent" {
+  description = "(Consul Enterprise only) If true, add policy rules to allow for snapshots to be sent to the specified s3 bucket"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_agent_bucket" {
+  description = "(Consul Enterprise only) The s3 bucket name the snapshot agent writes to.  Required if enable_snapshot_agent is true."
+  type        = string
+  default     = null
+}

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -35,13 +35,14 @@ data "aws_iam_policy_document" "auto_discover_cluster" {
 
 
 resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
-  count  = var.enabled ? 1 : 0
+  count  = "${var.enabled && var.enable_snapshot_agent ? 1 : 0}"
   name   = "consul-snapshot-agent"
   role   = var.iam_role_id
   policy = data.aws_iam_policy_document.snapshot_agent_to_s3.json
 }
 
 data "aws_iam_policy_document" "snapshot_agent_to_s3" {
+  count = "${var.enabled && var.enable_snapshot_agent ? 1 : 0}"
   statement {
     effect = "Allow"
 

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -62,6 +62,6 @@ data "aws_iam_policy_document" "snapshot_agent_to_s3" {
       "s3:DeleteObject"
     ]
 
-    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_s3_key_prefix}*.snap"]
+    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_s3_key_prefix}/*.snap"]
   }
 }

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -35,14 +35,14 @@ data "aws_iam_policy_document" "auto_discover_cluster" {
 
 
 resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
-  count  = "${var.enabled && var.enable_snapshot_agent ? 1 : 0}"
+  count  = ${var.enabled && var.enable_snapshot_agent} ? 1 : 0
   name   = "consul-snapshot-agent"
   role   = var.iam_role_id
   policy = data.aws_iam_policy_document.snapshot_agent_to_s3[0].json
 }
 
 data "aws_iam_policy_document" "snapshot_agent_to_s3" {
-  count = "${var.enabled && var.enable_snapshot_agent ? 1 : 0}"
+  count = ${var.enabled && var.enable_snapshot_agent} ? 1 : 0
   statement {
     effect = "Allow"
 

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -59,7 +59,8 @@ data "aws_iam_policy_document" "snapshot_agent_to_s3" {
 
     actions = [
       "s3:PutObject",
-      "s3:DeleteObject"
+      "s3:DeleteObject",
+      "s3:GetObject",
     ]
 
     resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_s3_key_prefix}/*.snap"]

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -43,24 +43,12 @@ resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
 
 data "aws_iam_policy_document" "snapshot_agent_to_s3" {
   count = "${var.enabled && var.enable_snapshot_agent}" ? 1 : 0
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "s3:ListBucket",
-      "s3:ListBucketVersions"
-    ]
-
-    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}"]
-  }
 
   statement {
     effect = "Allow"
 
     actions = [
-      "s3:PutObject",
-      "s3:DeleteObject",
-      "s3:GetObject",
+      "s3:PutObject"
     ]
 
     resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_s3_key_prefix}/*.snap"]

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -63,6 +63,6 @@ data "aws_iam_policy_document" "snapshot_agent_to_s3" {
       "s3:GetObject"
     ]
 
-    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/*"]
+    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_bucket_path}*.snap"]
   }
 }

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -59,10 +59,9 @@ data "aws_iam_policy_document" "snapshot_agent_to_s3" {
 
     actions = [
       "s3:PutObject",
-      "s3:DeleteObject",
-      "s3:GetObject"
+      "s3:DeleteObject"
     ]
 
-    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_bucket_path}*.snap"]
+    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/${var.snapshot_agent_s3_key_prefix}*.snap"]
   }
 }

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -38,7 +38,7 @@ resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
   count  = "${var.enabled && var.enable_snapshot_agent ? 1 : 0}"
   name   = "consul-snapshot-agent"
   role   = var.iam_role_id
-  policy = data.aws_iam_policy_document.snapshot_agent_to_s3.json
+  policy = data.aws_iam_policy_document.snapshot_agent_to_s3[0].json
 }
 
 data "aws_iam_policy_document" "snapshot_agent_to_s3" {

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -31,3 +31,37 @@ data "aws_iam_policy_document" "auto_discover_cluster" {
   }
 }
 
+# Additionally, if desired, add the necessary policy to allow snapshots to s3 buckets
+
+
+resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
+  count  = var.enabled ? 1 : 0
+  name   = "consul-snapshot-agent"
+  role   = var.iam_role_id
+  policy = data.aws_iam_policy_document.snapshot_agent_to_s3.json
+}
+
+data "aws_iam_policy_document" "snapshot_agent_to_s3" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketVersions"
+    ]
+
+    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetObject"
+    ]
+
+    resources = ["arn:aws:s3:::${var.snapshot_agent_bucket}/*"]
+  }
+}

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -35,14 +35,14 @@ data "aws_iam_policy_document" "auto_discover_cluster" {
 
 
 resource "aws_iam_role_policy" "snapshot_agent_to_s3" {
-  count  = ${var.enabled && var.enable_snapshot_agent} ? 1 : 0
+  count  = "${var.enabled && var.enable_snapshot_agent}" ? 1 : 0
   name   = "consul-snapshot-agent"
   role   = var.iam_role_id
   policy = data.aws_iam_policy_document.snapshot_agent_to_s3[0].json
 }
 
 data "aws_iam_policy_document" "snapshot_agent_to_s3" {
-  count = ${var.enabled && var.enable_snapshot_agent} ? 1 : 0
+  count = "${var.enabled && var.enable_snapshot_agent}" ? 1 : 0
   statement {
     effect = "Allow"
 

--- a/modules/consul-iam-policies/variables.tf
+++ b/modules/consul-iam-policies/variables.tf
@@ -14,3 +14,19 @@ variable "enabled" {
   default     = true
 }
 
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "enable_snapshot_agent" {
+  description = "(Consul Enterprise only) If true, add policy rules to allow for snapshots to be sent to the specified s3 bucket"
+  type        = bool
+  default     = false
+}
+
+variable "snapshot_agent_bucket" {
+  description = "(Consul Enterprise only) The s3 bucket name the snapshot agent writes to.  Required if enable_snapshot_agent is true."
+  type        = string
+  default     = null
+}

--- a/modules/consul-iam-policies/variables.tf
+++ b/modules/consul-iam-policies/variables.tf
@@ -30,3 +30,9 @@ variable "snapshot_agent_bucket" {
   type        = string
   default     = null
 }
+
+variable "snapshot_agent_bucket_path" {
+  description = "(Consul Enterprise only) The path within the s3 bucket that the snapshot agent writes to.  Defaults to consul-snapshot."
+  type        = string
+  default     = "consul-snapshot"
+}

--- a/modules/consul-iam-policies/variables.tf
+++ b/modules/consul-iam-policies/variables.tf
@@ -31,7 +31,7 @@ variable "snapshot_agent_bucket" {
   default     = null
 }
 
-variable "snapshot_agent_bucket_path" {
+variable "snapshot_agent_s3_key_prefix" {
   description = "(Consul Enterprise only) The path within the s3 bucket that the snapshot agent writes to.  Defaults to consul-snapshot."
   type        = string
   default     = "consul-snapshot"


### PR DESCRIPTION
Allow option for enabling snapshot agent, as well as bucket specification (where the snapshots are placed) and bucket path prefix.  This will only occur if IAM setup is enabled.  If someone is using a custom IAM role, they can just set up the required policy on their custom role.

Permissions for the snapshots match what is specified in the [Consul snapshot agent docs](https://www.consul.io/docs/commands/snapshot/agent.html#s3-required-permissions).