### PR TITLE
Add instance scale-in protection for consul-cluster

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -32,6 +32,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
 
   enabled_metrics = var.enabled_metrics
 
+  protect_from_scale_in = var.protect_from_scale_in
+
   tags = flatten(
     [
       {

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -260,3 +260,8 @@ variable "iam_instance_profile_name" {
   default     = null
 }
 
+variable "protect_from_scale_in" {
+  description = "(Optional) Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This change solve issue: https://github.com/hashicorp/terraform-aws-consul/issues/177

The changes are tested with an existing consul-cluster without scale-in protection. The optional scale-in protection is set to true.
The terraform plan output is here:
https://gist.github.com/mawa-jnd/476ab6680a68d6c4b1770a372cfff5aa

The change is:
- backward compatible
- has no downtime with default setup as changing the ASG will not automatically restart instances