### PR TITLE
Edit default value for availability_zones and subnet_ids vars to null

### DIFF
--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -59,13 +59,13 @@ variable "cluster_tag_value" {
 variable "subnet_ids" {
   description = "The subnet IDs into which the EC2 Instances should be deployed. We recommend one subnet ID per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "availability_zones" {
   description = "The availability zones into which the EC2 Instances should be deployed. We recommend one availability zone per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "ssh_key_name" {


### PR DESCRIPTION
Related to [Issue 181](https://github.com/hashicorp/terraform-aws-consul/issues/181)

Newest `provider-aws` version only allows us to set one of the 2 variables: `availability_zones and subnet_ids` when creating AutoScalingGroups.

As per @brikis98 suggestion, I am changing the default value of these 2 variables to null so they're no longer conflicting, allowing to set either of them when using the `consul_cluster` module. 