### PR TITLE
Allow configuration of dnsmasq listen address separate from the consul IP address

### DIFF
--- a/modules/install-dnsmasq/README.md
+++ b/modules/install-dnsmasq/README.md
@@ -50,6 +50,8 @@ The `install-dnsmasq` script accepts the following arguments:
 * `consul-ip IP`: The IP address to use for Consul. Optional. Default: `127.0.0.1`. This assumes a Consul agent is 
   running locally and connected to a Consul cluster.
 * `consul-dns-port PORT`: The port Consul uses for DNS requests. Optional. Default: `8600`.
+* `dnsmasq-listen-address IP`: The IP address for dnsmasq to listen on. Optional. Defaults to the value of `consul-ip`. 
+Make sure that the network interface you provide for the IP has already been configured before you pass it to dnsmasq.
 
 Example:
 

--- a/modules/install-dnsmasq/install-dnsmasq
+++ b/modules/install-dnsmasq/install-dnsmasq
@@ -10,6 +10,7 @@ set -e
 readonly DEFAULT_CONSUL_DOMAIN="consul"
 readonly DEFAULT_CONSUL_IP="127.0.0.1"
 readonly DEFAULT_CONSUL_DNS_PORT=8600
+readonly DEFAULT_DNSMASQ_LISTEN_ADDRESS=""
 
 readonly DNS_MASQ_CONFIG_DIR="/etc/dnsmasq.d"
 readonly CONSUL_DNS_MASQ_CONFIG_FILE="$DNS_MASQ_CONFIG_DIR/10-consul"
@@ -27,6 +28,7 @@ function print_usage {
   echo -e "  --consul-domain\tThe domain name to point to Consul. Optional. Default: $DEFAULT_CONSUL_DOMAIN."
   echo -e "  --consul-ip\t\tThe IP address to use for Consul. Optional. Default: $DEFAULT_CONSUL_IP."
   echo -e "  --consul-dns-port\tThe port Consul uses for DNS. Optional. Default: $DEFAULT_CONSUL_DNS_PORT."
+  echo -e "  --dnsmasq-listen-address\t\tThe IP address for dnsmasq to listen on. Optional. Defaults to the value of --consul-ip."
   echo
   echo "Example:"
   echo
@@ -98,15 +100,16 @@ function write_consul_config {
   local -r consul_domain="$1"
   local -r consul_ip="$2"
   local -r consul_port="$3"
+  local -r dnsmasq_listen_address="$4"
 
-  log_info "Configuring Dnsmasq to forward lookups of the '$consul_domain' domain to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
+  log_info "Configuring Dnsmasq to forward lookups of the '$consul_domain' domain on '$dnsmasq_listen_address' to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
   mkdir -p "$DNS_MASQ_CONFIG_DIR"
 
   sudo tee "$CONSUL_DNS_MASQ_CONFIG_FILE" <<EOF
 # Enable forward lookup of the '$consul_domain' domain:
 server=/${consul_domain}/${consul_ip}#${consul_port}
 
-listen-address=${consul_ip}
+listen-address=${dnsmasq_listen_address}
 bind-interfaces
 EOF
 }
@@ -115,6 +118,7 @@ function install {
   local consul_domain="$DEFAULT_CONSUL_DOMAIN"
   local consul_ip="$DEFAULT_CONSUL_IP"
   local consul_dns_port="$DEFAULT_CONSUL_DNS_PORT"
+  local dnsmasq_listen_address="$DEFAULT_DNSMASQ_LISTEN_ADDRESS"
 
   while [[ $# -gt 0 ]]; do
     local key="$1"
@@ -135,6 +139,11 @@ function install {
         consul_dns_port="$2"
         shift
         ;;
+      --dnsmasq-listen-address)
+        assert_not_empty "$key" "$2"
+        dnsmasq_listen_address="$2"
+        shift
+        ;;
       --help)
         print_usage
         exit
@@ -148,10 +157,14 @@ function install {
 
     shift
   done
+  
+  if [[ -z "$dnsmasq_listen_address" ]]; then
+    dnsmasq_listen_address="$consul_ip"
+  fi
 
   log_info "Starting Dnsmasq install"
   install_dnsmasq "$consul_ip"
-  write_consul_config "$consul_domain" "$consul_ip" "$consul_dns_port"
+  write_consul_config "$consul_domain" "$consul_ip" "$consul_dns_port" "$dnsmasq_listen_address"
   log_info "Dnsmasq install complete!"
 }
 


### PR DESCRIPTION
This pull request allows the configuration of the dnsmasq `listen-address`. Previously, the only way to modify this also modified the consul IP address that dnsmasq routed to. This is relatively backward compatible. Users of the default consul-ip default value will see the same behavior, as the dnsmasq listen-address defaults to the same value. However, if a user was running consul on a different IP, and ran dnsmasq on that same IP to accommodate this script, they will need to update their usage of this script.