### PR TITLE
Update repo to work with TF 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 ---
-workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-consul
-
 defaults: &defaults
-  working_directory: *workspace_root
   docker:
     - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:tf13
 
@@ -13,8 +10,6 @@ jobs:
     steps:
       - checkout
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
-      - attach_workspace:
-          at: *workspace_root
       - run:
           # Fail the build if the pre-commit hooks don't pass. Note: if you run $ pre-commit install locally within this repo, these hooks will
           # execute automatically every time before you commit, ensuring the build never fails at this step!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,10 @@ workspace_root: &workspace_root /go/src/github.com/hashicorp/terraform-aws-consu
 defaults: &defaults
   working_directory: *workspace_root
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.13
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:tf13
 
 version: 2
 jobs:
-  validate_terraform:
-    docker:
-      - image: hashicorp/terraform
-    steps:
-      - checkout
-      - run:
-          name: Validate Terraform Formatting
-          command: '[ -z "$(terraform fmt -write=false)" ] || { terraform fmt -write=false -diff; exit 1; }'
-
   test:
     <<: *defaults
     steps:
@@ -24,6 +15,14 @@ jobs:
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
       - attach_workspace:
           at: *workspace_root
+      - run:
+          # Fail the build if the pre-commit hooks don't pass. Note: if you run $ pre-commit install locally within this repo, these hooks will
+          # execute automatically every time before you commit, ensuring the build never fails at this step!
+          name: run pre-commit hooks
+          command: |
+            pip install pre-commit==1.21.0 cfgv==2.0.1
+            pre-commit install
+            pre-commit run --all-files
       - run:
           command: |
             mkdir -p /tmp/logs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev:  v0.1.10
+    hooks:
+      - id: terraform-fmt
+      - id: gofmt

--- a/examples/example-with-custom-asg-role/main.tf
+++ b/examples/example-with-custom-asg-role/main.tf
@@ -8,10 +8,12 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/example-with-encryption/main.tf
+++ b/examples/example-with-encryption/main.tf
@@ -8,10 +8,12 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/example-with-encryption/packer/consul-with-certs.json
+++ b/examples/example-with-encryption/packer/consul-with-certs.json
@@ -78,9 +78,12 @@
     "source": "{{user `tls_private_key_path`}}",
     "destination": "/tmp/consul.key.pem"
   },{
+    "type": "shell",
+    "inline": ["mkdir -p /tmp/terraform-aws-consul"]
+  },{
     "type": "file",
-    "source": "{{template_dir}}/../../../../terraform-aws-consul",
-    "destination": "/tmp"
+    "source": "{{template_dir}}/../../../",
+    "destination": "/tmp/terraform-aws-consul"
   },{
     "type": "shell",
     "inline": [

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,12 @@
 
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-client-security-group-rules/main.tf
+++ b/modules/consul-client-security-group-rules/main.tf
@@ -1,9 +1,12 @@
 ## ---------------------------------------------------------------------------------------------------------------------
-# THESE TEMPLATES REQUIRE TERRAFORM VERSION 0.12 AND ABOVE
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 ## ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -1,10 +1,12 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-iam-policies/main.tf
+++ b/modules/consul-iam-policies/main.tf
@@ -1,9 +1,12 @@
-### ---------------------------------------------------------------------------------------------------------------------
-# THESE TEMPLATES REQUIRE TERRAFORM VERSION 0.12 AND ABOVE
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -1,9 +1,11 @@
 # ----------------------------------------------------------------------------------------------------------------------
 # REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
 # ----------------------------------------------------------------------------------------------------------------------
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/test/aws_helpers.go
+++ b/test/aws_helpers.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"testing"
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"testing"
 )
 
 // Get the IP address from a randomly chosen EC2 Instance in an Auto Scaling Group of the given name in the given

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/packer"
 )
@@ -20,6 +21,11 @@ func buildAmi(t *testing.T, packerTemplatePath string, packerBuildName string, a
 		Env: map[string]string{
 			CONSUL_AMI_TEMPLATE_VAR_DOWNLOAD_URL: downloadUrl,
 		},
+		RetryableErrors: map[string]string{
+			"Error waiting for AMI: Failed with ResourceNotReady error": "https://www.packer.io/docs/builders/amazon.html#resourcenotready-error",
+		},
+		MaxRetries:         3,
+		TimeBetweenRetries: 10 * time.Second,
 	}
 
 	return packer.BuildAmi(t, options)


### PR DESCRIPTION
1. Update `required_version` to `0.12.26` everywhere.
1. Add pre-commit hooks.
1. Update version numbers in CI build.
1. Run `go fmt`.
1. Fix folder copy in a Packer template. Our previous Circle CI Docker image used to check out the repo into a folder called `terraform-aws-consul`, so the Packer template could use a `file` provisioner to copy it from that folder name. Our new Circle CI Docker image uses a different folder name (e.g., `project`), so we have to update the Packer template to work even if it doesn't know the folder name.
1. Add retries for Packer builds for what looks like a transient build failure.