### PR TITLE
Fix deploy step in build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ jobs:
       # We generally only want to build AMIs on new releases, but when we are setting up AMIs in a new account for the
       # first time, we want to build the AMIs but NOT run automated tests, since those tests will fail without an existing
       # AMI already in the AWS Account.
-      - run: /go/src/github.com/hashicorp/terraform-aws-consul/_ci/publish-amis.sh "ubuntu16-ami"
-      - run: /go/src/github.com/hashicorp/terraform-aws-consul/_ci/publish-amis.sh "amazon-linux-ami"
+      - run: _ci/publish-amis.sh "ubuntu16-ami"
+      - run: _ci/publish-amis.sh "amazon-linux-ami"
 
 workflows:
   version: 2

--- a/_ci/publish-amis.sh
+++ b/_ci/publish-amis.sh
@@ -7,10 +7,10 @@
 
 set -e
 
-readonly PACKER_TEMPLATE_PATH="/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/examples/consul-ami/consul.json"
+readonly PACKER_TEMPLATE_PATH="examples/consul-ami/consul.json"
 readonly PACKER_TEMPLATE_DEFAULT_REGION="us-east-1"
 readonly AMI_PROPERTIES_FILE="/tmp/ami.properties"
-readonly AMI_LIST_MARKDOWN_DIR="/go/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/_docs"
+readonly AMI_LIST_MARKDOWN_DIR="_docs"
 readonly GIT_COMMIT_MESSAGE="Add latest AMI IDs."
 readonly GIT_USER_NAME="gruntwork-ci"
 readonly GIT_USER_EMAIL="ci@gruntwork.io"


### PR DESCRIPTION
In https://github.com/hashicorp/terraform-aws-consul/pull/192, I updated the build to use a different Docker image, with a newer version of Go that doesn't rely on everything running in the `/go/xxx` path. Unfortunately, I forgot to update the deploy portion of the build, which publishes AMIs, and was still relying on those paths. This PR fixes the deploy step. I created a temporary, internal release to validate it, as the deploy step doesn't run on branches, by default: https://github.com/hashicorp/terraform-aws-consul/releases/tag/v0.8.1-internal-test