### PR TITLE
Add encrypted root device and additional EBS volumes

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -109,8 +109,8 @@ resource "aws_launch_configuration" "launch_configuration" {
       volume_size           = lookup(ebs_block_device.value, "volume_size", null)
       volume_type           = lookup(ebs_block_device.value, "volume_type", null)
     }
-  }  
-  
+  }
+
   # Important note: whenever using a launch configuration with an auto scaling group, you must set
   # create_before_destroy = true. However, as soon as you set create_before_destroy = true in one resource, you must
   # also set it in every resource that it depends on, or you'll get an error about cyclic dependencies (especially when

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -97,7 +97,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     delete_on_termination = var.root_volume_delete_on_termination
     encrypted             = var.root_volume_encrypted
   }
-  
+
   dynamic "ebs_block_device" {
     for_each = var.ebs_block_devices
     content {

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -102,7 +102,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     for_each = var.ebs_block_devices
     content {
       delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
-      device_name           = ebs_block_device.value.device_name
+      device_name           = lookup(ebs_block_device.value, "device_name", null)
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -95,8 +95,22 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_type           = var.root_volume_type
     volume_size           = var.root_volume_size
     delete_on_termination = var.root_volume_delete_on_termination
+    encrypted             = var.root_volume_encrypted
   }
-
+  
+  dynamic "ebs_block_device" {
+    for_each = var.ebs_block_devices
+    content {
+      delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
+      device_name           = ebs_block_device.value.device_name
+      encrypted             = lookup(ebs_block_device.value, "encrypted", null)
+      iops                  = lookup(ebs_block_device.value, "iops", null)
+      snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
+      volume_size           = lookup(ebs_block_device.value, "volume_size", null)
+      volume_type           = lookup(ebs_block_device.value, "volume_type", null)
+    }
+  }  
+  
   # Important note: whenever using a launch configuration with an auto scaling group, you must set
   # create_before_destroy = true. However, as soon as you set create_before_destroy = true in one resource, you must
   # also set it in every resource that it depends on, or you'll get an error about cyclic dependencies (especially when

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -166,11 +166,12 @@ variable "root_volume_delete_on_termination" {
 
 variable "root_volume_encrypted" {
   description = "Encrypt the volume at rest"
+  type        = bool
   default     = false
 }
 
 variable "ebs_block_device" {
-  description = "Additional EBS block devices to attach to autoscaling instances" 
+  description = "Additional EBS block devices to attach to autoscaling instances"
   type        = list(map(string))
   default     = []
 }

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -164,6 +164,17 @@ variable "root_volume_delete_on_termination" {
   default     = true
 }
 
+variable "root_volume_encrypted" {
+  description = "Encrypt the volume at rest"
+  default     = false
+}
+
+variable "ebs_block_devices" {
+  description = "List of EBS volumes"
+  type        = list
+  default     = []
+}
+
 variable "wait_for_capacity_timeout" {
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
   type        = string

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -169,9 +169,9 @@ variable "root_volume_encrypted" {
   default     = false
 }
 
-variable "ebs_block_devices" {
-  description = "List of EBS volumes"
-  type        = list
+variable "ebs_block_device" {
+  description = "Additional EBS block devices to attach to autoscaling instances" 
+  type        = list(map(string))
   default     = []
 }
 

--- a/modules/setup-systemd-resolved/README.md
+++ b/modules/setup-systemd-resolved/README.md
@@ -11,6 +11,7 @@ DNS Forwarding Guide](https://www.consul.io/docs/guides/forwarding.html) and [Gi
 This script has been tested on the following operating systems:
 
 * Ubuntu 18.04
+* Ubuntu 20.04
 
 ## Quick start
 

--- a/modules/setup-systemd-resolved/setup-systemd-resolved
+++ b/modules/setup-systemd-resolved/setup-systemd-resolved
@@ -82,7 +82,7 @@ function configure_systemd_resolved {
   local -r consul_port="$3"
 
   UBUNTU_VERSION=`lsb_release -s -r`
-  if [ "$UBUNTU_VERSION" == "18.04" ]; then
+  if [ "$UBUNTU_VERSION" == "18.04" ] || [ "$UBUNTU_VERSION" == "20.04" ]; then
     log_info "Configuring systemd-resolved to forward lookups of the '$consul_domain' domain to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
 
     sudo iptables -t nat -A OUTPUT -d localhost -p udp -m udp --dport 53 -j REDIRECT --to-ports $consul_port

--- a/modules/setup-systemd-resolved/setup-systemd-resolved
+++ b/modules/setup-systemd-resolved/setup-systemd-resolved
@@ -82,7 +82,7 @@ function configure_systemd_resolved {
   local -r consul_port="$3"
 
   UBUNTU_VERSION=`lsb_release -s -r`
-  if [ "$UBUNTU_VERSION" == "18.04" ] || [ "$UBUNTU_VERSION" == "20.04" ]; then
+  if [ "$UBUNTU_VERSION" == "18.04" ]; then
     log_info "Configuring systemd-resolved to forward lookups of the '$consul_domain' domain to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
 
     sudo iptables -t nat -A OUTPUT -d localhost -p udp -m udp --dport 53 -j REDIRECT --to-ports $consul_port


### PR DESCRIPTION
Fixes #160 

Add option to use an encrypted root volume

Allow for additional EBS volumes to be mounted