### PR TITLE
Update systemd-resolved script for Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To deploy Consul clients for production using this repo:
 1. Use the [install-consul module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) to install Consul alongside your application code.
 1. Before booting your app, execute the [run-consul script](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/run-consul) with `--client` flag.
 1. Your app can now use the local Consul agent for service discovery and key/value storage.
-1. Optionally, you can use the [install-dnsmasq module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) for Ubuntu 16.04 and Amazon Linux 2 or [setup-systemd-resolved](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/setup-systemd-resolved) for Ubuntu 18.04 to configure Consul as the DNS for a
+1. Optionally, you can use the [install-dnsmasq module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) for Ubuntu 16.04 and Amazon Linux 2 or [setup-systemd-resolved](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/setup-systemd-resolved) for Ubuntu 18.04 and Ubuntu 20.04 to configure Consul as the DNS for a
    specific domain (e.g. `.consul`) so that URLs such as `foo.service.consul` resolve automatically to the IP 
    address(es) for a service `foo` registered in Consul (all other domain names will be continue to resolve using the
    default resolver on the OS).
@@ -97,7 +97,7 @@ Gruntwork can help with:
   for URLs such as `foo.service.consul`.
 
 * [setup-systemd-resolved module](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/setup-systemd-resolved): Setup [systemd-resolved](https://www.freedesktop.org/software/systemd/man/resolved.conf.html)
-  for ubuntu 18.04 and configure it to forward requests for a specific domain to Consul. This allows you to use Consul as a DNS server
+  for Ubuntu 18.04 and Ubuntu 20.04 and configure it to forward requests for a specific domain to Consul. This allows you to use Consul as a DNS server
   for URLs such as `foo.service.consul`.
 
 * [consul-iam-policies](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/consul-iam-policies): Defines the IAM policies necessary for a Consul cluster. 

--- a/examples/consul-ami/README.md
+++ b/examples/consul-ami/README.md
@@ -7,6 +7,7 @@ top of:
  
 1. Ubuntu 16.04
 1. Ubuntu 18.04
+1. Ubuntu 20.04
 1. Amazon Linux 2
 
 These AMIs will have [Consul](https://www.consul.io/) installed and configured to automatically join a cluster during 
@@ -16,7 +17,7 @@ services](https://www.consul.io/intro/getting-started/services.html) for instruc
 in Consul). To see how to deploy this AMI, check out the [consul-cluster example](https://github.com/hashicorp/terraform-aws-consul/tree/master/examples/root-example). 
 
 For more info on Consul installation and configuration, check out the 
-[install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) and [install-dnsmasq](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) for Ubuntu 16.04 and Amazon Linux 2 or [setup-systemd-resolved](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/setup-systemd-resolved) for Ubuntu 18.04 documentation.
+[install-consul](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-consul) and [install-dnsmasq](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/install-dnsmasq) for Ubuntu 16.04 and Amazon Linux 2 or [setup-systemd-resolved](https://github.com/hashicorp/terraform-aws-consul/tree/master/modules/setup-systemd-resolved) for Ubuntu 18.04 and Ubuntu 20.04 documentation.
 
 ## Dependencies
 1.  AWSCLI must be installed on the base AMI in order for run-consul to run
@@ -70,7 +71,7 @@ provisioner. Instead of:
     "pause_before": "30s"
   },{
     "type": "shell",
-    "only": ["ubuntu18-ami"],
+    "only": ["ubuntu18-ami", "ubuntu20-ami"],
     "inline": [
       "/tmp/terraform-aws-consul/modules/setup-systemd-resolved/setup-systemd-resolved"
     ],
@@ -99,7 +100,7 @@ Your code should look more like this:
     "pause_before": "30s"
   },{
     "type": "shell",
-    "only": ["ubuntu18-ami"],
+    "only": ["ubuntu18-ami", "ubuntu20-ami"],
     "inline": [
       "/tmp/terraform-aws-consul/modules/setup-systemd-resolved/setup-systemd-resolved"
     ],

--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -45,6 +45,27 @@
     },
     "ssh_username": "ubuntu"
   },{
+    "name": "ubuntu20-ami",
+    "ami_name": "consul-ubuntu-{{isotime | clean_resource_name}}-{{uuid}}",
+    "ami_description": "An Ubuntu 20.04 AMI that has Consul installed.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "associate_public_ip_address": true,
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+
+  },{
     "name": "amazon-linux-2-ami",
     "ami_name": "consul-amazon-linux-2-{{isotime | clean_resource_name}}-{{uuid}}",
     "ami_description": "An Amazon Linux 2 AMI that has Consul installed.",
@@ -91,7 +112,7 @@
     "pause_before": "30s"
   },{
     "type": "shell",
-    "only": ["ubuntu18-ami"],
+    "only": ["ubuntu18-ami", "ubuntu20-ami"],
     "inline": [
       "/tmp/terraform-aws-consul/modules/setup-systemd-resolved/setup-systemd-resolved"
     ],

--- a/examples/example-with-encryption/packer/consul-with-certs.json
+++ b/examples/example-with-encryption/packer/consul-with-certs.json
@@ -46,6 +46,25 @@
     },
     "ssh_username": "ubuntu"
   },{
+    "name": "ubuntu20-ami",
+    "ami_name": "consul-with-encryption-ubuntu-20.04-{{isotime | clean_resource_name}}-{{uuid}}",
+    "ami_description": "An Ubuntu 20.04 AMI that has Consul installed and TLS certificates.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  },{
     "ami_name": "consul-with-encryption-amazon-linux-2-{{isotime | clean_resource_name}}-{{uuid}}",
     "ami_description": "An Amazon Linux 2 AMI that has Consul installed and TLS certificates.",
     "instance_type": "t2.micro",
@@ -99,7 +118,7 @@
     "pause_before": "30s"
   },{
     "type": "shell",
-    "only": ["ubuntu18-ami"],
+    "only": ["ubuntu18-ami", "ubuntu20-ami"],
     "inline": [
       "/tmp/terraform-aws-consul/modules/setup-systemd-resolved/setup-systemd-resolved"
     ],

--- a/modules/run-consul/README.md
+++ b/modules/run-consul/README.md
@@ -5,6 +5,7 @@ script has been tested on the following operating systems:
 
 * Ubuntu 16.04
 * Ubuntu 18.04
+* Ubuntu 20.04
 * Amazon Linux 2
 
 There is a good chance it will work on other flavors of Debian, CentOS, and RHEL as well.

--- a/modules/setup-systemd-resolved/README.md
+++ b/modules/setup-systemd-resolved/README.md
@@ -11,6 +11,7 @@ DNS Forwarding Guide](https://www.consul.io/docs/guides/forwarding.html) and [Gi
 This script has been tested on the following operating systems:
 
 * Ubuntu 18.04
+* Ubuntu 20.04
 
 ## Quick start
 

--- a/modules/setup-systemd-resolved/setup-systemd-resolved
+++ b/modules/setup-systemd-resolved/setup-systemd-resolved
@@ -82,7 +82,7 @@ function configure_systemd_resolved {
   local -r consul_port="$3"
 
   UBUNTU_VERSION=`lsb_release -s -r`
-  if [ "$UBUNTU_VERSION" == "18.04" ]; then
+  if [ "$UBUNTU_VERSION" == "18.04" ] || [ "$UBUNTU_VERSION" == "20.04" ]; then
     log_info "Configuring systemd-resolved to forward lookups of the '$consul_domain' domain to $consul_ip:$consul_port in $CONSUL_DNS_MASQ_CONFIG_FILE"
 
     sudo iptables -t nat -A OUTPUT -d localhost -p udp -m udp --dport 53 -j REDIRECT --to-ports $consul_port

--- a/test/consul_cluster_test.go
+++ b/test/consul_cluster_test.go
@@ -17,6 +17,11 @@ func TestConsulClusterWithUbuntu18Ami(t *testing.T) {
 }
 
 // Test the example in the root folder
+func TestConsulClusterWithUbuntu20Ami(t *testing.T) {
+	t.Parallel()
+	runConsulClusterTest(t, "ubuntu20-ami", ".", "../examples/consul-ami/consul.json", "ubuntu", "")
+}
+// Test the example in the root folder
 func TestConsulClusterWithAmazonLinuxAmi(t *testing.T) {
 	t.Parallel()
 	runConsulClusterTest(t, "amazon-linux-2-ami", ".", "../examples/consul-ami/consul.json", "ec2-user", "")

--- a/test/consul_cluster_with_custom_asg_role_test.go
+++ b/test/consul_cluster_with_custom_asg_role_test.go
@@ -22,6 +22,14 @@ func TestConsulClusterWithCustomASGRoleUbuntu18Ami(t *testing.T) {
 	runConsulClusterTestWithVars(t, "ubuntu18-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ubuntu", terraformVars, "")
 }
 
+func TestConsulClusterWithCustomASGRoleUbuntu20Ami(t *testing.T) {
+	t.Parallel()
+	terraformVars := map[string]interface{}{
+		"consul_service_linked_role_suffix": random.UniqueId(),
+	}
+	runConsulClusterTestWithVars(t, "ubuntu20-ami", "examples/example-with-custom-asg-role", "../examples/consul-ami/consul.json", "ubuntu", terraformVars, "")
+}
+
 func TestConsulClusterWithCustomASGRoleAmazonLinuxAmi(t *testing.T) {
 	t.Parallel()
 	terraformVars := map[string]interface{}{

--- a/test/consul_cluster_with_encryption_test.go
+++ b/test/consul_cluster_with_encryption_test.go
@@ -12,6 +12,11 @@ func TestConsulClusterWithEncryptionUbuntu18Ami(t *testing.T) {
 	runConsulClusterTest(t, "ubuntu18-ami", "examples/example-with-encryption", "../examples/example-with-encryption/packer/consul-with-certs.json", "ubuntu", "")
 }
 
+func TestConsulClusterWithEncryptionUbuntu20Ami(t *testing.T) {
+	t.Parallel()
+	runConsulClusterTest(t, "ubuntu20-ami", "examples/example-with-encryption", "../examples/example-with-encryption/packer/consul-with-certs.json", "ubuntu", "")
+}
+
 func TestConsulClusterWithEncryptionAmazonLinuxAmi(t *testing.T) {
 	t.Parallel()
 	runConsulClusterTest(t, "amazon-linux-2-ami", "examples/example-with-encryption", "../examples/example-with-encryption/packer/consul-with-certs.json", "ec2-user", "")

--- a/test/consul_enterprise_test.go
+++ b/test/consul_enterprise_test.go
@@ -16,6 +16,11 @@ func TestConsulInstallFromURLWithUbuntu18Ami(t *testing.T) {
 	runConsulClusterTest(t, "ubuntu18-ami", ".", "../examples/consul-ami/consul.json", "ubuntu", getUrlFromEnv(t))
 }
 
+func TestConsulInstallFromURLWithUbuntu20Ami(t *testing.T) {
+	t.Parallel()
+	runConsulClusterTest(t, "ubuntu20-ami", ".", "../examples/consul-ami/consul.json", "ubuntu", getUrlFromEnv(t))
+}
+
 func TestConsulInstallFromURLWithAmazonLinuxAmi(t *testing.T) {
 	t.Parallel()
 	runConsulClusterTest(t, "amazon-linux-2-ami", ".", "../examples/consul-ami/consul.json", "ec2-user", getUrlFromEnv(t))


### PR DESCRIPTION
Systemd is also available on Ubuntu 20.04. The updates will allow the provisioning script to run.