### PR TITLE
Add security group for consul default https api port 8501

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,9 @@ module "consul_servers" {
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
 
+  # To create security group for consul HTTPS API. HTTPS API (Optional) Is off by default.
+  enable_https_port = var.enable_https_port
+
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
   allowed_ssh_cidr_blocks = ["0.0.0.0/0"]

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ module "consul_servers" {
   vpc_id     = data.aws_vpc.default.id
   subnet_ids = data.aws_subnet_ids.default.ids
 
-  # To create security group for consul HTTPS API. HTTPS API (Optional) Is off by default.
+  # If set to true, this allows access to the consul HTTPS API
   enable_https_port = var.enable_https_port
 
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -185,6 +185,8 @@ module "security_group_rules" {
   http_api_port   = var.http_api_port
   https_api_port  = var.https_api_port
   dns_port        = var.dns_port
+
+  enable_https_port = var.enable_https_port
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -183,6 +183,7 @@ module "security_group_rules" {
   serf_lan_port   = var.serf_lan_port
   serf_wan_port   = var.serf_wan_port
   http_api_port   = var.http_api_port
+  https_api_port  = var.https_api_port
   dns_port        = var.dns_port
 }
 

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -231,7 +231,7 @@ variable "http_api_port" {
 }
 
 variable "https_api_port" {
-  description = "The port used by clients to talk to the HTTP API"
+  description = "The port used by clients to talk to the HTTPS API. Only used if enable_https_port is set to true."
   type        = number
   default     = 8501
 }
@@ -267,7 +267,7 @@ variable "enable_iam_setup" {
 }
 
 variable "enable_https_port" {
-  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  description = "If set to true, allow access to the Consul HTTPS port defined via the https_api_port variable."
   type        = bool
   default     = false
 }

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -266,6 +266,12 @@ variable "enable_iam_setup" {
   default     = true
 }
 
+variable "enable_https_port" {
+  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  type        = bool
+  default     = false
+}
+
 variable "iam_instance_profile_name" {
   description = "If enable_iam_setup is false then this will be the name of the IAM instance profile to attach"
   type        = string

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -230,6 +230,12 @@ variable "http_api_port" {
   default     = 8500
 }
 
+variable "https_api_port" {
+  description = "The port used by clients to talk to the HTTP API"
+  type        = number
+  default     = 8501
+}
+
 variable "dns_port" {
   description = "The port used to resolve DNS queries."
   type        = number

--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -67,6 +67,17 @@ resource "aws_security_group_rule" "allow_http_api_inbound" {
   security_group_id = var.security_group_id
 }
 
+resource "aws_security_group_rule" "allow_https_api_inbound" {
+  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
+  type        = "ingress"
+  from_port   = var.https_api_port
+  to_port     = var.https_api_port
+  protocol    = "tcp"
+  cidr_blocks = var.allowed_inbound_cidr_blocks
+
+  security_group_id = var.security_group_id
+}
+
 resource "aws_security_group_rule" "allow_dns_tcp_inbound" {
   count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
@@ -144,6 +155,17 @@ resource "aws_security_group_rule" "allow_http_api_inbound_from_security_group_i
   security_group_id = var.security_group_id
 }
 
+resource "aws_security_group_rule" "allow_https_api_inbound_from_security_group_ids" {
+  count                    = var.allowed_inbound_security_group_count
+  type                     = "ingress"
+  from_port                = var.https_api_port
+  to_port                  = var.https_api_port
+  protocol                 = "tcp"
+  source_security_group_id = element(var.allowed_inbound_security_group_ids, count.index)
+
+  security_group_id = var.security_group_id
+}
+
 resource "aws_security_group_rule" "allow_dns_tcp_inbound_from_security_group_ids" {
   count                    = var.allowed_inbound_security_group_count
   type                     = "ingress"
@@ -212,6 +234,16 @@ resource "aws_security_group_rule" "allow_http_api_inbound_from_self" {
   type      = "ingress"
   from_port = var.http_api_port
   to_port   = var.http_api_port
+  protocol  = "tcp"
+  self      = true
+
+  security_group_id = var.security_group_id
+}
+
+resource "aws_security_group_rule" "allow_https_api_inbound_from_self" {
+  type      = "ingress"
+  from_port = var.https_api_port
+  to_port   = var.https_api_port
   protocol  = "tcp"
   self      = true
 

--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -156,7 +156,7 @@ resource "aws_security_group_rule" "allow_http_api_inbound_from_security_group_i
 }
 
 resource "aws_security_group_rule" "allow_https_api_inbound_from_security_group_ids" {
-  count                    = var.allowed_inbound_security_group_count
+  count                    = var.enable_https_port ? var.allowed_inbound_security_group_count : 0
   type                     = "ingress"
   from_port                = var.https_api_port
   to_port                  = var.https_api_port
@@ -241,6 +241,7 @@ resource "aws_security_group_rule" "allow_http_api_inbound_from_self" {
 }
 
 resource "aws_security_group_rule" "allow_https_api_inbound_from_self" {
+  count     = var.enable_https_port ? 1 : 0
   type      = "ingress"
   from_port = var.https_api_port
   to_port   = var.https_api_port

--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "allow_http_api_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_https_api_inbound" {
-  count       = length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
+  count       = var.enable_https_port ? 1 : 0
   type        = "ingress"
   from_port   = var.https_api_port
   to_port     = var.https_api_port

--- a/modules/consul-security-group-rules/variables.tf
+++ b/modules/consul-security-group-rules/variables.tf
@@ -62,7 +62,7 @@ variable "http_api_port" {
 }
 
 variable "https_api_port" {
-  description = "The port used by clients to talk to the HTTPS API"
+  description = "The port used by clients to talk to the HTTPS API. Only used if enable_https_port is set to true."
   type        = number
   default     = 8501
 }
@@ -74,7 +74,7 @@ variable "dns_port" {
 }
 
 variable "enable_https_port" {
-  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  description = "If set to true, allow access to the Consul HTTPS port defined via the https_api_port variable."
   type        = bool
   default     = false
 }

--- a/modules/consul-security-group-rules/variables.tf
+++ b/modules/consul-security-group-rules/variables.tf
@@ -61,6 +61,12 @@ variable "http_api_port" {
   default     = 8500
 }
 
+variable "https_api_port" {
+  description = "The port used by clients to talk to the HTTPS API"
+  type        = number
+  default     = 8501
+}
+
 variable "dns_port" {
   description = "The port used to resolve DNS queries."
   type        = number

--- a/modules/consul-security-group-rules/variables.tf
+++ b/modules/consul-security-group-rules/variables.tf
@@ -73,3 +73,8 @@ variable "dns_port" {
   default     = 8600
 }
 
+variable "enable_https_port" {
+  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -60,3 +60,8 @@ variable "spot_price" {
   default     = null
 }
 
+variable "enable_https_port" {
+  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  type        = bool
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "spot_price" {
 }
 
 variable "enable_https_port" {
-  description = "HTTPS API (Optional) Is off by default. If true, security group for consul HTTPS API is created."
+  description = "If set to true, allow access to the Consul HTTPS port defined via the https_api_port variable."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
PR addresses part of issue https://github.com/hashicorp/terraform-aws-consul/issues/92

Add security group for consul default https api port 8501.
https://www.consul.io/docs/install/ports