### PR TITLE
Add `permissions_boundary` for created IAM role.

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -216,6 +216,8 @@ resource "aws_iam_role" "instance_role" {
   name_prefix        = var.cluster_name
   assume_role_policy = data.aws_iam_policy_document.instance_role.json
 
+  permissions_boundary = var.iam_permissions_boundary
+
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
   # when you try to do a terraform destroy.

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -278,6 +278,12 @@ variable "iam_instance_profile_name" {
   default     = null
 }
 
+variable "iam_permissions_boundary" {
+  description = "If set, restricts the created IAM role to the given permissions boundary"
+  type        = string
+  default     = null
+}
+
 variable "protect_from_scale_in" {
   description = "(Optional) Allows setting instance protection. The autoscaling group will not select instances with this setting for termination during scale in events."
   type        = bool


### PR DESCRIPTION
Provides flexibility to users for setting `permissions_boundary` to the created IAM role.

Defaults to `null` to preserve the same behavior as before.