### PR TITLE
Update agent configuration

### DIFF
--- a/examples/consul-ami/consul.json
+++ b/examples/consul-ami/consul.json
@@ -2,7 +2,7 @@
   "min_packer_version": "1.5.4",
   "variables": {
     "aws_region": "us-east-1",
-    "consul_version": "1.5.1",
+    "consul_version": "1.9.2",
     "download_url": "{{env `CONSUL_DOWNLOAD_URL`}}"
   },
   "builders": [{

--- a/examples/example-with-custom-asg-role/main.tf
+++ b/examples/example-with-custom-asg-role/main.tf
@@ -159,4 +159,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/examples/example-with-custom-asg-role/outputs.tf
+++ b/examples/example-with-custom-asg-role/outputs.tf
@@ -57,4 +57,3 @@ output "consul_servers_cluster_tag_key" {
 output "consul_servers_cluster_tag_value" {
   value = module.consul_servers.cluster_tag_value
 }
-

--- a/examples/example-with-custom-asg-role/variables.tf
+++ b/examples/example-with-custom-asg-role/variables.tf
@@ -101,4 +101,3 @@ variable "consul_service_linked_role_suffix" {
   type        = string
   default     = "test-consul-service-linked-role"
 }
-

--- a/examples/example-with-encryption/main.tf
+++ b/examples/example-with-encryption/main.tf
@@ -149,4 +149,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/examples/example-with-encryption/outputs.tf
+++ b/examples/example-with-encryption/outputs.tf
@@ -57,4 +57,3 @@ output "consul_servers_cluster_tag_key" {
 output "consul_servers_cluster_tag_value" {
   value = module.consul_servers.cluster_tag_value
 }
-

--- a/examples/example-with-encryption/packer/consul-with-certs.json
+++ b/examples/example-with-encryption/packer/consul-with-certs.json
@@ -1,8 +1,8 @@
 {
-  "min_packer_version": "0.12.0",
+  "min_packer_version": "1.5.4",
   "variables": {
     "aws_region": "us-east-1",
-    "consul_version": "1.0.5",
+    "consul_version": "1.9.2",
     "ca_public_key_path": "{{template_dir}}/ca.crt.pem",
     "tls_public_key_path": "{{template_dir}}/consul.crt.pem",
     "tls_private_key_path": "{{template_dir}}/consul.key.pem"

--- a/examples/example-with-encryption/variables.tf
+++ b/examples/example-with-encryption/variables.tf
@@ -95,4 +95,3 @@ variable "key_file_path" {
   type        = string
   default     = "/opt/consul/tls/consul.key.pem"
 }
-

--- a/main.tf
+++ b/main.tf
@@ -176,4 +176,3 @@ data "aws_subnet_ids" "default" {
 
 data "aws_region" "current" {
 }
-

--- a/modules/run-consul/run-consul
+++ b/modules/run-consul/run-consul
@@ -239,7 +239,8 @@ function generate_consul_config {
   local instance_id=""
   local instance_ip_address=""
   local instance_region=""
-  local ui="false"
+  # https://www.consul.io/docs/agent/options#ui-1
+  local ui_config_enabled="false"
 
   instance_id=$(get_instance_id)
   instance_ip_address=$(get_instance_ip_address)
@@ -274,7 +275,7 @@ EOF
     cluster_size=$(get_cluster_size "$instance_tags" "$instance_region")
 
     bootstrap_expect="\"bootstrap_expect\": $cluster_size,"
-    ui="true"
+    ui_config_enabled="true"
   fi
 
   local autopilot_configuration
@@ -327,7 +328,12 @@ EOF
   $gossip_encryption_configuration
   $rpc_encryption_configuration
   $autopilot_configuration
-  "ui": $ui
+  "telemetry": {
+    "disable_compat_1.9": true
+  },
+  "ui_config": {
+    "enabled": $ui_config_enabled
+  }
 }
 EOF
 )

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,4 +57,3 @@ output "consul_servers_cluster_tag_key" {
 output "consul_servers_cluster_tag_value" {
   value = module.consul_servers.cluster_tag_value
 }
-


### PR DESCRIPTION
* bump `min_packer_version` -> `1.5.4`
* bump `consul_version` -> `1.9.2`
* update consul service configuration
  * Replace deprecated `ui` field by `ui_config` object: https://www.consul.io/docs/agent/options\#ui-1
  * Add `telemetry { disable_compat_1.9 = true }` to disable metrics deprecated in `v1.9`: https://www.consul.io/docs/agent/options\#telemetry-disable_compat_1.9
