### PR TITLE
Fix for #210: can't find Consul binary when executing through Packer

### DIFF
--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -300,7 +300,7 @@ function install {
     install_tls_certificates "$path" "$user" "$ca_file_path" "$cert_file_path" "$key_file_path"
   fi
 
-  if command -v consul; then
+  if sudo bash -c "command -v consul"; then
     log_info "Consul install complete!";
   else
     log_info "Could not find consul command. Aborting.";

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -302,7 +302,7 @@ function install {
 
   # This command is run with sudo rights so that it will succeed in cases where image hardening alters the permissions
   # on the directories where Consul may be installed. See https://github.com/hashicorp/terraform-aws-consul/issues/210.
-  if sudo bash -c "command -v consul"; then
+  if sudo -E PATH=$PATH bash -c "command -v consul"; then
     log_info "Consul install complete!";
   else
     log_info "Could not find consul command. Aborting.";

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -300,6 +300,8 @@ function install {
     install_tls_certificates "$path" "$user" "$ca_file_path" "$cert_file_path" "$key_file_path"
   fi
 
+  # This command is run with sudo rights so that it will succeed in cases where image hardening alters the permissions
+  # on the directories where Consul may be installed. See https://github.com/hashicorp/terraform-aws-consul/issues/210.
   if sudo bash -c "command -v consul"; then
     log_info "Consul install complete!";
   else


### PR DESCRIPTION
The install-consul script now grants read and execute access to the directory where the Consul binary is installed. This fixes the issue reported under #210, while also allowing users who sign in under a different login to use the Consul binary for administrative purposes if necessary.