### PR TITLE
Update NOTICE with license info

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 terraform-aws-consul
 Copyright 2017 Gruntwork, Inc.
 
-This product includes software developed at Gruntwork (http://www.gruntwork.io/).
+This product includes software developed at Gruntwork (http://www.gruntwork.io/). See LICENSE for terms.


### PR DESCRIPTION
This removes any ambiguity in the NOTICE as to how the code is licensed. Fixes #214.