### PR TITLE
Set up http_api access correctly

### DIFF
--- a/modules/consul-security-group-rules/main.tf
+++ b/modules/consul-security-group-rules/main.tf
@@ -68,7 +68,7 @@ resource "aws_security_group_rule" "allow_http_api_inbound" {
 }
 
 resource "aws_security_group_rule" "allow_https_api_inbound" {
-  count       = var.enable_https_port ? 1 : 0
+  count       = var.enable_https_port && length(var.allowed_inbound_cidr_blocks) >= 1 ? 1 : 0
   type        = "ingress"
   from_port   = var.https_api_port
   to_port     = var.https_api_port


### PR DESCRIPTION
Received an error using the module in our terraform:

Error: One of ['cidr_blocks', 'ipv6_cidr_blocks', 'self', 'source_security_group_id', 'prefix_list_ids'] must be set to create an AWS Security Group Rule 
Error on .terraform/modules/consul_servers/modules/consul-security-group-rules/main.tf line 70, in resource "aws_security_group_rule" "allow_https_api_inbound": 
Error: resource "aws_security_group_rule" "allow_https_api_inbound" { 

If the module is given only security groups and not cidr ranges, a security group rule is created without all the necessary attributes.  Change applies the right boolean logic for this case.