### PR TITLE
Update install-consul logic to determine CPU arch which makes it run on Graviton based EC2 instances

### DIFF
--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -166,7 +166,8 @@ function fetch_binary {
   local -r version="$1"
   local download_url="$2"
 
-  local -r cpu_arch="$(uname -m)"
+  local cpu_arch
+  cpu_arch="$(uname -m)"
   local binary_arch=""
   case "$cpu_arch" in
     x86_64)
@@ -191,7 +192,8 @@ function fetch_binary {
       # $ uname -m
       # $ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"
       #
-      local -r vfp_tag="$(readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args)"
+      local vfp_tag
+      vfp_tag="$(readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args)"
       if [[ ! $vfp_tag  ]]; then
         binary_arch="armelv5"
       else

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -166,8 +166,46 @@ function fetch_binary {
   local -r version="$1"
   local download_url="$2"
 
-  if [[ -z "$download_url" && -n "$version" ]];  then
-    download_url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_amd64.zip"
+  local -r cpu_arch="$(uname -m)"
+  local binary_arch=""
+  case "$cpu_arch" in
+    x86_64)
+      binary_arch="amd64"
+      ;;
+    x86)
+      binary_arch="386"
+      ;;
+    aarch64)
+      binary_arch="arm64"
+      ;;
+    arm*)
+      # The following info is taken from https://www.consul.io/downloads
+      #
+      # Note for ARM users:
+      #
+      # Use Armelv5 for all 32-bit armel systems
+      # Use Armhfv6 for all armhf systems with v6+ architecture
+      # Use Arm64 for all v8 64-bit architectures
+      # The following commands can help determine the right version for your system:
+      #
+      # $ uname -m
+      # $ readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args && echo "armhf" || echo "armel"
+      #
+      local -r vfp_tag="$(readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args)"
+      if [[ ! $vfp_tag  ]]; then
+        binary_arch="armelv5"
+      else
+        binary_arch="armhfv6"
+      fi
+      ;;
+    *)
+      log_error "CPU architecture $cpu_arch is not a supported by Consul."
+      exit 1
+      ;;
+    esac
+
+  if [[ -z "$download_url" && -n "$version" ]]; then
+    download_url="https://releases.hashicorp.com/consul/${version}/consul_${version}_linux_${binary_arch}.zip"
   fi
 
   retry \

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -194,7 +194,7 @@ function fetch_binary {
       #
       local vfp_tag
       vfp_tag="$(readelf -a /proc/self/exe | grep -q -c Tag_ABI_VFP_args)"
-      if [[ ! $vfp_tag  ]]; then
+      if [[ -z $vfp_tag  ]]; then
         binary_arch="armelv5"
       else
         binary_arch="armhfv6"

--- a/modules/install-consul/install-consul
+++ b/modules/install-consul/install-consul
@@ -175,7 +175,7 @@ function fetch_binary {
     x86)
       binary_arch="386"
       ;;
-    aarch64)
+    arm64|aarch64)
       binary_arch="arm64"
       ;;
     arm*)


### PR DESCRIPTION
# Changes
- Include logic to determine binary architecture from returned value from `uname -m`

# Verification
- Tested on a `c6g.*` EC2 instance running Amazon Linux 2
```sh
$ uname -m
aarch64
```
- Tested on a Raspberry Pi 3B running Raspbian
```sh
$ uname -m
armv7l
```
- Tested on some good 'ol `amd64` Linux
```sh
$ uname -m
x86_64
```