### PR TITLE
Instance refresh

### DIFF
--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -65,6 +65,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
       role_arn                = lookup(initial_lifecycle_hook.value, "role_arn", null)
     }
   }
+  
+  instance_refresh = var.instance_refresh
 
   lifecycle {
     # As of AWS Provider 3.x, inline load_balancers and target_group_arns

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -67,17 +67,17 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   }
   
   dynamic "instance_refresh" {
-    for_each = var.instance_refresh == null ? [] : [var.instance_refresh]
+    for_each = range(var.instance_refresh == null ? 0 : 1)
     content {
-      strategy = instance_refresh.strategy
+      strategy = var.instance_refresh.strategy
       dynamic "preferences" {
-        for_each = lookup(instance_refresh, "preferences", null) == null ? [] : [instance_refresh.preferences]
+        for_each = range(lookup(var.instance_refresh, "preferences", null) == null ? 0 : 1)
         content {
-          instance_warmup        = lookup(preferences, "instance_warmup", null)
-          min_healthy_percentage = lookup(preferences, "min_healthy_percentage", null)
+          instance_warmup        = lookup(var.instance_refresh.preferences, "instance_warmup", null)
+          min_healthy_percentage = lookup(var.instance_refresh.preferences, "min_healthy_percentage", null)
         }
       }
-      triggers = lookup(instance_refresh, "triggers", null)
+      triggers = lookup(var.instance_refresh, "triggers", null)
     }
   }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -69,15 +69,15 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   dynamic "instance_refresh" {
     for_each = var.instance_refresh == null ? [] : [var.instance_refresh]
     content {
-      strategy = var.instance_refresh.strategy == null ? [] : [var.instance_refresh_strategy]
+      strategy = instance_refresh.strategy
       dynamic "preferences" {
-        for_each = lookup(var.instance_refresh, "preferences", null) == null ? [] : [var.instance_refresh.preferences]
+        for_each = lookup(instance_refresh, "preferences", null) == null ? [] : [instance_refresh.preferences]
         content {
-          instance_warmup        = lookup(var.instance_refresh.preferences, "instance_warmup", null)
-          min_healthy_percentage = lookup(var.instance_refresh.preferences, "min_healthy_percentage", null)
+          instance_warmup        = lookup(preferences, "instance_warmup", null)
+          min_healthy_percentage = lookup(preferences, "min_healthy_percentage", null)
         }
       }
-      triggers = lookup(var.instance_refresh, "triggers", null)
+      triggers = lookup(instance_refresh, "triggers", null)
     }
   }
 

--- a/modules/consul-cluster/main.tf
+++ b/modules/consul-cluster/main.tf
@@ -66,7 +66,20 @@ resource "aws_autoscaling_group" "autoscaling_group" {
     }
   }
   
-  instance_refresh = var.instance_refresh
+  dynamic "instance_refresh" {
+    for_each = var.instance_refresh == null ? [] : [var.instance_refresh]
+    content {
+      strategy = var.instance_refresh.strategy == null ? [] : [var.instance_refresh_strategy]
+      dynamic "preferences" {
+        for_each = lookup(var.instance_refresh, "preferences", null) == null ? [] : [var.instance_refresh.preferences]
+        content {
+          instance_warmup        = lookup(var.instance_refresh.preferences, "instance_warmup", null)
+          min_healthy_percentage = lookup(var.instance_refresh.preferences, "min_healthy_percentage", null)
+        }
+      }
+      triggers = lookup(var.instance_refresh, "triggers", null)
+    }
+  }
 
   lifecycle {
     # As of AWS Provider 3.x, inline load_balancers and target_group_arns

--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -148,6 +148,22 @@ variable "lifecycle_hooks" {
   }
 }
 
+variable "instance_refresh" {
+  description = "Setting for an instance refresh triggered after the group is updated.  The value is an object that is defined in the instance_refresh block of the aws_autoscaling_group resource.  The default is not to trigger an instance refresh"
+  type        = any
+  default     = null
+  
+  #    example = {
+  #        strategy          = string : ROLLING
+  #        preferences       = {
+  #          instance_warmup          = int
+  #          min_healthy_percentage   = int
+  #        }
+  #        triggers          = list(string)
+  #    }
+  
+}
+    
 variable "associate_public_ip_address" {
   description = "If set to true, associate a public IP address with each EC2 Instance in the cluster."
   type        = bool


### PR DESCRIPTION
The module doesn't expose the instance refresh properties of the underlying auto-scaling group - so it isn't possible to trigger an instance update as part of a deployment.

Adding the necessary properties/docs to achieve this