### PR TITLE
use `-raw` when getting values from `terraform output`

### DIFF
--- a/examples/consul-examples-helper/consul-examples-helper.sh
+++ b/examples/consul-examples-helper/consul-examples-helper.sh
@@ -47,7 +47,7 @@ function get_required_terraform_output {
   local readonly output_name="$1"
   local output_value
 
-  output_value=$(terraform output -no-color "$output_name")
+  output_value=$(terraform output -no-color -raw "$output_name")
 
   if [[ -z "$output_value" ]]; then
     log_error "Unable to find a value for Terraform output $output_name"


### PR DESCRIPTION
this prevent the extra `"..."` quotes which messes up the `aws ec2 describe-instances` call