### PR TITLE
Expose `subnet_ids` var to root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "consul_servers" {
   })
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = var.subnet_ids != null ? var.subnet_ids : data.aws_subnet_ids.default.ids
 
   # If set to true, this allows access to the consul HTTPS API
   enable_https_port = var.enable_https_port
@@ -128,7 +128,7 @@ module "consul_clients" {
   })
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = var.subnet_ids != null ? var.subnet_ids : data.aws_subnet_ids.default.ids
 
   # To make testing easier, we allow Consul and SSH requests from any IP address here but in a production
   # deployment, we strongly recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,9 @@ variable "enable_https_port" {
   type        = bool
   default     = false
 }
+
+variable "subnet_ids" {
+  description = "The subnet IDs into which the EC2 Instances should be deployed. We recommend one subnet ID per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
+  type        = list(string)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "enable_https_port" {
 }
 
 variable "subnet_ids" {
-  description = "The subnet IDs into which the EC2 Instances should be deployed. We recommend one subnet ID per node in the cluster_size variable. At least one of var.subnet_ids or var.availability_zones must be non-empty."
+  description = "The subnet IDs into which the EC2 Instances should be deployed. We recommend one subnet ID per node in the cluster_size variable."
   type        = list(string)
   default     = null
 }


### PR DESCRIPTION
## Description

This PR exposes the `subnet_ids` optional var to the root module, so that it can be specified if necessary.

### Documentation

Documented in the variable descriptions.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.