### PR TITLE
Remove type constraint to allow explicit null

### DIFF
--- a/modules/consul-cluster/variables.tf
+++ b/modules/consul-cluster/variables.tf
@@ -156,7 +156,6 @@ variable "associate_public_ip_address" {
 
 variable "spot_price" {
   description = "The maximum hourly price to pay for EC2 Spot Instances."
-  type        = number
   default     = null
 }
 


### PR DESCRIPTION
## Description

When you use terragrunt or even a terraform module calling terraform-aws-consul module you may have `spot_price` defined but you don't want to assign any value because you want the instances to be on-demand. However since it's templated with the use of a variable, `spot_price` is always present. Unfortunately the `type=number` for `spot_price` makes it impossible to assign an empty value because terraform/terragrunt will tell you that `null` or `""` is not a number.

The change is a simple as **not** enforcing the `type = number` in `variables.tf`

### Use case (simplified version)
`terragrunt.hcl`
```
terraform {
  source = "git::git@inhouse.net:infrastructure/terraform-modules/cloud-modules.git///aws-consul-server-cluster/"
}
...
inputs = {
  ...
  cluster_name   = "foobar"
  spot_price   = local.SPOT
  ...
}
```

`terraform in-house module`
```
variable "spot_price" {
  description = "If defined, let's use spot instances with a price UP TO this value"
  default     = null
}

module "consul_servers" {
  source = "git::git@github.com:TomGudman/terraform-aws-consul.git//modules/consul-cluster?ref=v0.11.1"

  cluster_name  = var.cluster_name
  cluster_size  = var.num_servers
  instance_type = var.instance_type

  spot_price = var.spot_price
}

```

### Documentation
N/A

### TODOs / Related issues
There isn't any issue number yet and I couldn't find one.